### PR TITLE
Channel custom instead of test and local

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-iitc-manager",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Library for managing IITC plugins",
   "main": "src/index.js",
   "type": "module",

--- a/src/manager.js
+++ b/src/manager.js
@@ -75,8 +75,7 @@ import {parseMeta, ajaxGet, getUID, wait, clearWait, isSet} from './helpers.js';
  * @memberOf manager
  * @property {string} release=https://iitc.app/build/release - Release branch.
  * @property {string} beta=https://iitc.app/build/beta - Beta branch.
- * @property {string} test=https://iitc.app/build/test - Test builds branch.
- * @property {string} local=http://localhost:8000 - Webserver address for local development.
+ * @property {string} custom=http://localhost:8000 - URL address of a custom repository.
  */
 
 /**
@@ -157,7 +156,7 @@ export class Manager {
      * Changes the update channel.
      *
      * @async
-     * @param {"release" | "beta" | "test" | "local"} channel - Update channel for IITC and plugins.
+     * @param {"release" | "beta" | "custom"} channel - Update channel for IITC and plugins.
      * @return {Promise<void>}
      */
     async setChannel(channel) {
@@ -171,7 +170,7 @@ export class Manager {
      *
      * @async
      * @param {number} interval - Update check interval in seconds.
-     * @param {"release" | "beta" | "test" | "local" | undefined} [channel=undefined] - Update channel for IITC and plugins.
+     * @param {"release" | "beta" | "custom" | undefined} [channel=undefined] - Update channel for IITC and plugins.
      * If not specified, the current channel is used.
      * @return {Promise<void>}
      */
@@ -186,6 +185,20 @@ export class Manager {
     }
 
     /**
+     * Changes the URL of the repository with IITC and plugins for the custom channel.
+     *
+     * @async
+     * @param {string} url - URL of the repository.
+     * @return {Promise<void>}
+     */
+    async setCustomChannelUrl(url) {
+        const network_host = await this.storage.get(['network_host']).then((data) => data.network_host);
+        network_host.custom = url;
+        await this.storage.set({ network_host: network_host });
+        this.network_host = network_host;
+    }
+
+    /**
      * Set values for the class properties.
      *
      * @async
@@ -196,8 +209,7 @@ export class Manager {
         this.network_host = await this.syncStorage('network_host', {
             release: 'https://iitc.app/build/release',
             beta: 'https://iitc.app/build/beta',
-            test: 'https://iitc.app/build/test',
-            local: 'http://localhost:8000'
+            custom: 'http://localhost:8000'
         }, this.config.network_host);
         this.is_daemon = await this.syncStorage('is_daemon', true, this.config.is_daemon);
     }
@@ -382,7 +394,6 @@ export class Manager {
         let update_check_interval =
             storage[this.channel + '_update_check_interval'] * 60 * 60;
         if (!update_check_interval) update_check_interval = 24 * 60 * 60;
-        if (this.channel === 'local') update_check_interval = 5; // check every 5 seconds
 
         if (
             !isSet(storage[this.channel + '_last_modified']) ||

--- a/src/manager.js
+++ b/src/manager.js
@@ -157,13 +157,32 @@ export class Manager {
      * Changes the update channel.
      *
      * @async
-     * @param channel
+     * @param {"release" | "beta" | "test" | "local"} channel - Update channel for IITC and plugins.
      * @return {Promise<void>}
      */
     async setChannel(channel) {
         await this._save({ channel: channel, last_check_update: null });
         this.channel = channel;
         await this.checkUpdates();
+    }
+
+    /**
+     * Changes the update check interval. If the interval for the current channel changes, a forced update check is started to apply the new interval.
+     *
+     * @async
+     * @param {number} interval - Update check interval in seconds.
+     * @param {"release" | "beta" | "test" | "local" | undefined} [channel=undefined] - Update channel for IITC and plugins.
+     * If not specified, the current channel is used.
+     * @return {Promise<void>}
+     */
+    async setUpdateCheckInterval(interval, channel) {
+        if (typeof channel === 'undefined') channel = this.channel;
+
+        const data = {};
+        data[channel + '_update_check_interval'] = interval;
+        await this.storage.set(data);
+
+        if (channel === this.channel) await this.checkUpdates(true);
     }
 
     /**

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -2,11 +2,16 @@
 
 import {isSet} from './helpers.js';
 
-export async function migrate(storage) {
+export function number_of_migrations() {
+    return migrates.length;
+}
 
-    const migrates = [
-        migration_0001
-    ];
+const migrates = [
+    migration_0001,
+    migration_0002
+];
+
+export async function migrate(storage) {
     const local = await storage.get([
         'release_plugins_flat',
         'test_plugins_flat',
@@ -44,5 +49,12 @@ async function migration_0001(local) {
                 plugin_obj['category'] = 'Misc';
             }
         }
+    }
+}
+
+async function migration_0002(local) {
+    if (['test', 'local'].includes(local.channel)) {
+        local.channel = 'release';
+        local.network_host.custom = local.network_host.local;
     }
 }

--- a/test/fixtures/custom/meta.json
+++ b/test/fixtures/custom/meta.json
@@ -1,0 +1,4 @@
+{
+  "categories": {},
+  "iitc_version": "0.99.0"
+}

--- a/test/fixtures/custom/total-conversion-build.meta.js
+++ b/test/fixtures/custom/total-conversion-build.meta.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @author         jonatkins
 // @name           IITC: Ingress intel map total conversion
-// @version        0.32.1
+// @version        0.99.0
 // @description    Total conversion for the ingress intel map.
 // @run-at         document-end
 // @id             total-conversion-build
 // @namespace      https://github.com/IITC-CE/ingress-intel-total-conversion
-// @updateURL      http://127.0.0.1:31606/release/total-conversion-build.meta.js
-// @downloadURL    http://127.0.0.1:31606/release/total-conversion-build.user.js
+// @updateURL      http://127.0.0.1:31606/custom/total-conversion-build.meta.js
+// @downloadURL    http://127.0.0.1:31606/custom/total-conversion-build.user.js
 // @match          https://intel.ingress.com/*
 // @grant          none
 // ==/UserScript==

--- a/test/fixtures/custom/total-conversion-build.user.js
+++ b/test/fixtures/custom/total-conversion-build.user.js
@@ -1,0 +1,20 @@
+// ==UserScript==
+// @author         jonatkins
+// @name           IITC: Ingress intel map total conversion
+// @version        0.99.0
+// @description    Total conversion for the ingress intel map.
+// @run-at         document-end
+// @id             total-conversion-build
+// @namespace      https://github.com/IITC-CE/ingress-intel-total-conversion
+// @updateURL      https://iitc.app/build/release/total-conversion-build.meta.js
+// @downloadURL    https://iitc.app/build/release/total-conversion-build.user.js
+// @match          https://intel.ingress.com/*
+// @grant          none
+// ==/UserScript==
+
+var script = document.createElement('script');
+var info = {};
+if (typeof GM_info !== 'undefined' && GM_info && GM_info.script) info.script = { version: GM_info.script.version, name: GM_info.script.name, description: GM_info.script.description };
+script.appendChild(document.createTextNode('('+ wrapper +')('+JSON.stringify(info)+');'));
+(document.body || document.head || document.documentElement).appendChild(script);
+

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -56,6 +56,13 @@ describe('manage.js integration tests', function () {
         });
     });
 
+    describe('Check channel', function() {
+        it('Should return beta', async function() {
+            const channel = await storage.get(['channel']).then((data) => data.channel);
+            expect(channel).to.equal('beta');
+        });
+    });
+
     describe('setChannel', function() {
         it('Should not return an error', async function() {
             const channel = await manager.setChannel('release');

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -15,7 +15,7 @@ const expectThrowsAsync = async (method, errorMessage) => {
     }
     expect(error).to.be.an('Error');
     if (errorMessage) {
-        expect(error.message).to.equal(errorMessage);
+        expect(error['message']).to.equal(errorMessage);
     }
 };
 
@@ -31,8 +31,7 @@ describe('manage.js integration tests', function () {
             network_host: {
                 release: 'http://127.0.0.1:31606/release',
                 beta: 'http://127.0.0.1:31606/beta',
-                test: 'http://127.0.0.1:31606/test',
-                local: 'http://127.0.0.1:8000'
+                custom: 'http://127.0.0.1/',
             },
             inject_user_script: function callBack(data){
                 expect(data).to.include('// ==UserScript==');
@@ -436,6 +435,35 @@ describe('manage.js integration tests', function () {
                 db_data['release_plugins_flat'][external_1_uid]['override'],
                 "release_plugins_flat['override']: " + external_1_uid
             ).to.not.be.true;
+        });
+    });
+
+    describe('Custom repository', function() {
+        const custom_repo = 'http://127.0.0.1:31606/custom';
+
+        it('Setting the URL of the custom repository', async function () {
+            const run = await manager.setCustomChannelUrl(custom_repo);
+            expect(run).to.be.undefined;
+        });
+
+        it('Check the URL of the custom repository', async function () {
+            const network_host = await storage.get(['network_host']).then(data => data.network_host);
+            expect(network_host.custom).to.equal(custom_repo);
+        });
+
+        it('Switching to a custom channel', async function() {
+            const channel = await manager.setChannel('custom');
+            expect(channel).to.be.undefined;
+        });
+
+        it('Check the IITC version', async function() {
+            const script = await storage.get(['custom_iitc_code']).then(data => data['custom_iitc_code']);
+            expect(script).to.include('@version        0.99.0');
+        });
+
+        it('Switching back to the Release channel', async function() {
+            const channel = await manager.setChannel('release');
+            expect(channel).to.be.undefined;
         });
     });
 

--- a/test/manager.spec.js
+++ b/test/manager.spec.js
@@ -70,6 +70,13 @@ describe('manage.js integration tests', function () {
         });
     });
 
+    describe('setUpdateCheckInterval', function() {
+        it('Should not return an error', async function() {
+            const fn = await manager.setUpdateCheckInterval(24 * 60 * 60, 'release');
+            expect(fn).to.be.undefined;
+        });
+    });
+
     describe('inject', function() {
         it('Should not return an error', async function() {
             const inject = await manager.inject();

--- a/test/migrations.spec.js
+++ b/test/migrations.spec.js
@@ -1,7 +1,7 @@
 // @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
 
 import { describe, it } from 'mocha';
-import { migrate } from '../src/migrations.js';
+import {migrate, number_of_migrations} from '../src/migrations.js';
 import storage from '../test/storage.js';
 import { expect } from 'chai';
 
@@ -35,7 +35,7 @@ describe('test migrations', function () {
         });
         it('The value of storage_version field has changed', async function() {
             const db_data = await storage.get(['storage_version']);
-            expect(db_data['storage_version']).to.equal(1);
+            expect(db_data['storage_version']).to.equal(number_of_migrations());
         });
     });
 


### PR DESCRIPTION
- The `test` and `local` channels have been replaced by `custom` channel
- New public methods: `setCustomChannelUrl`, `setUpdateCheckInterval`.
- Refactoring and fixing code that synchronizes values in storage and class instance parameters when creating a class.