### PR TITLE
Improvements to provide information when adding a new plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-iitc-manager",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "Library for managing IITC plugins",
   "main": "src/index.js",
   "type": "module",

--- a/src/manager.js
+++ b/src/manager.js
@@ -200,12 +200,13 @@ export class Manager extends Worker {
 
     /**
      * Allows adding third-party UserScript plugins to IITC.
+     * Returns the dictionary of installed or updated plugins.
      *
      * @async
      * @param {Object[]} scripts - Array of UserScripts.
      * @param {plugin} scripts[].meta - Parsed "meta" object of UserScript.
      * @param {string} scripts[].code - UserScript code.
-     * @return {Promise<void>}
+     * @return {Promise<Object.<string, plugin>>}
      */
     async addUserScripts(scripts) {
         let local = await this.storage.get([
@@ -225,6 +226,7 @@ export class Manager extends Worker {
         if (!isSet(plugins_local)) plugins_local = {};
         if (!isSet(plugins_user)) plugins_user = {};
 
+        const installed_scripts = {};
         scripts.forEach((script) => {
             let meta = script['meta'];
             const code = script['code'];
@@ -262,6 +264,7 @@ export class Manager extends Worker {
                 plugins_flat[plugin_uid] = { ...plugins_user[plugin_uid] };
             }
             plugins_flat[plugin_uid]['user'] = true;
+            installed_scripts[plugin_uid] = plugins_flat[plugin_uid];
         });
 
         await this._save({
@@ -270,5 +273,6 @@ export class Manager extends Worker {
             plugins_local: plugins_local,
             plugins_user: plugins_user,
         });
+        return installed_scripts;
     }
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -275,4 +275,17 @@ export class Manager extends Worker {
         });
         return installed_scripts;
     }
+
+    /**
+     * Returns information about requested plugin by UID.
+     *
+     * @async
+     * @param {string} uid - Plugin UID.
+     * @return {Promise<plugin|null>}
+     */
+    async getPluginInfo(uid) {
+        let all_plugins = await this.storage.get([this.channel + '_plugins_flat']).then((data) => data[this.channel + '_plugins_flat']);
+        if (all_plugins === undefined) return null;
+        return all_plugins[uid];
+    }
 }

--- a/test/manager.1.build-in.spec.js
+++ b/test/manager.1.build-in.spec.js
@@ -84,5 +84,12 @@ describe('manage.js build-in plugins integration tests', function () {
 
             expect(db_data['release_plugins_flat'][second_plugin_uid]['status'], 'release_plugins_flat: ' + second_plugin_uid).to.equal('on');
         });
+
+        it('Info about plugin', async function () {
+            const info = await manager.getPluginInfo(first_plugin_uid);
+            expect(info).to.be.an('object');
+            expect(info['uid']).to.be.equal(first_plugin_uid);
+            expect(info['status']).to.be.equal('off');
+        });
     });
 });

--- a/test/manager.2.external.spec.js
+++ b/test/manager.2.external.spec.js
@@ -302,7 +302,7 @@ describe('manage.js external plugins integration tests', function () {
             ];
             const installed = {
                 'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion': {
-                    uid: 'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    uid: external_1_uid,
                     id: 'ap-stats',
                     author: 'Hollow011',
                     description: 'Displays the per-team AP gains available in the current view.',
@@ -329,6 +329,16 @@ describe('manage.js external plugins integration tests', function () {
             expect(db_data['release_plugins_flat'][external_1_uid]['code'], "release_plugins_flat['code']: " + external_1_uid).to.equal(external_code);
 
             expect(db_data['release_plugins_flat'][external_1_uid]['override'], "release_plugins_flat['override']: " + external_1_uid).to.be.true;
+        });
+
+        it('Info about plugin', async function () {
+            const info = await manager.getPluginInfo(external_1_uid);
+            expect(info).to.be.an('object');
+            expect(info['uid']).to.be.equal(external_1_uid);
+            expect(info['status']).to.be.equal('on');
+            expect(info['override']).to.be.true;
+            expect(info['user']).to.be.true;
+            expect(info['code']).to.be.equal(external_code);
         });
 
         it('Disable external plugin', async function () {

--- a/test/manager.2.external.spec.js
+++ b/test/manager.2.external.spec.js
@@ -67,8 +67,20 @@ describe('manage.js external plugins integration tests', function () {
                     code: external_code,
                 },
             ];
+            const installed = {
+                'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion': {
+                    uid: 'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    id: 'bookmarks1',
+                    namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    name: 'Bookmarks for maps and portals',
+                    category: 'Controls',
+                    status: 'on',
+                    user: true,
+                    code: external_code,
+                },
+            };
             const run = await manager.addUserScripts(scripts);
-            expect(run).to.be.undefined;
+            expect(run).to.deep.equal(installed);
 
             const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
             expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(first_plugin_uid, second_plugin_uid, external_1_uid);
@@ -92,8 +104,20 @@ describe('manage.js external plugins integration tests', function () {
                     code: external_code,
                 },
             ];
+            const installed = {
+                'Bookmarks2 for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion': {
+                    uid: 'Bookmarks2 for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    id: 'bookmarks2',
+                    namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    name: 'Bookmarks2 for maps and portals',
+                    category: 'Misc',
+                    status: 'on',
+                    user: true,
+                    code: external_code,
+                },
+            };
             const run = await manager.addUserScripts(scripts);
-            expect(run).to.be.undefined;
+            expect(run).to.deep.equal(installed);
 
             const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
             expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(
@@ -230,8 +254,20 @@ describe('manage.js external plugins integration tests', function () {
                     code: external_code,
                 },
             ];
+            const installed = {
+                'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion': {
+                    uid: 'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    id: 'bookmarks1',
+                    namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    name: 'Bookmarks for maps and portals',
+                    category: 'Controls',
+                    status: 'on',
+                    user: true,
+                    code: external_code,
+                },
+            };
             const run = await manager.addUserScripts(scripts);
-            expect(run).to.be.undefined;
+            expect(run).to.deep.equal(installed);
         });
 
         it('Check external plugin', async function () {
@@ -264,8 +300,25 @@ describe('manage.js external plugins integration tests', function () {
                     code: external_code,
                 },
             ];
+            const installed = {
+                'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion': {
+                    uid: 'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    id: 'ap-stats',
+                    author: 'Hollow011',
+                    description: 'Displays the per-team AP gains available in the current view.',
+                    filename: 'ap-stats.user.js',
+                    namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+                    name: 'Available AP statistics',
+                    category: 'Info',
+                    status: 'on',
+                    override: true,
+                    user: true,
+                    version: '0.4.2',
+                    code: external_code,
+                },
+            };
             const run = await manager.addUserScripts(scripts);
-            expect(run).to.be.undefined;
+            expect(run).to.deep.equal(installed);
 
             const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
             expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(first_plugin_uid, second_plugin_uid);


### PR DESCRIPTION
* New public method: `manager.getPluginInfo()`. It returns information about requested plugin by UID.
* Implemented returning a dictionary of installed or updated plugins in `manager.addUserScripts()` method