### PR TITLE
add store distribution exception to GPL-3.0

### DIFF
--- a/COPYING.STORE
+++ b/COPYING.STORE
@@ -1,0 +1,14 @@
+The IITC-CE developers are aware that the terms of service that apply to apps
+and extensions distributed via application stores (such as Apple App Store,
+Google Play Store, and others) may conflict with rights granted under the
+lib-iitc-manager library license, the GNU General Public License, version 3 or
+(at your option) any later version. The copyright holders of the
+lib-iitc-manager library do not wish this conflict to prevent the
+otherwise-compliant distribution of applications and extensions using this
+library via these distribution platforms. Therefore, we have committed not to
+pursue any license violation that results solely from the conflict between the
+GNU GPLv3 or any later version and the application store terms of service. In
+other words, as long as you comply with the GPL in all other respects,
+including its requirements to provide users with source code and the text of
+the license, we will not object to your distribution of applications and
+extensions that use the lib-iitc-manager library through application stores.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,9 @@ const uniqId = getUniqId("tmp");
 
 ## License
 
-[GPL-3.0 license](/LICENSE)
+lib-iitc-manager is licensed under [GNU General Public License v3.0 (GPL-3.0)](/LICENSE).
+For distribution through application stores (Apple App Store, Google Play Store, and others),
+please refer to the [COPYING.STORE](/COPYING.STORE) file, which provides an exception for the application store
+distribution requirements while maintaining GPL-3.0 compliance for the source code.
+
+

--- a/src/backup.js
+++ b/src/backup.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2023-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { isSet, parseMeta, sanitizeFileName } from './helpers.js';
 import deepmerge from '@bundled-es-modules/deepmerge';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 export let wait_timeout_id = null;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { Manager } from './manager.js';
 import { parseMeta, ajaxGet, getUniqId, getUID, check_meta_match_pattern, wait, clearWait } from './helpers.js';

--- a/src/manager.js
+++ b/src/manager.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { Worker } from './worker.js';
 import * as migrations from './migrations.js';

--- a/src/matching.js
+++ b/src/matching.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2023-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 const CACHE = {};
 const RE_URL = /(.*?):\/\/([^/]*)\/(.*)/;

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { isSet, getUID, parseMeta } from './helpers.js';
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { ajaxGet, clearWait, getUID, isSet, parseMeta, wait } from './helpers.js';
 

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it } from 'mocha';
 import * as helpers from '../src/helpers.js';

--- a/test/manager.0.base.spec.js
+++ b/test/manager.0.base.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';

--- a/test/manager.1.build-in.spec.js
+++ b/test/manager.1.build-in.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';

--- a/test/manager.2.external.spec.js
+++ b/test/manager.2.external.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';

--- a/test/manager.3.repo.spec.js
+++ b/test/manager.3.repo.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';

--- a/test/manager.9.backup.spec.js
+++ b/test/manager.9.backup.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';

--- a/test/matching.spec.js
+++ b/test/matching.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2023-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it } from 'mocha';
 import { check_matching, humanize_match } from '../src/matching.js';

--- a/test/migrations.spec.js
+++ b/test/migrations.spec.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { before, describe, it } from 'mocha';
 import { migrate, number_of_migrations } from '../src/migrations.js';

--- a/test/storage.js
+++ b/test/storage.js
@@ -1,4 +1,4 @@
-// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3
+// Copyright (C) 2022-2025 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 const store = {};
 


### PR DESCRIPTION
Add COPYING.STORE file to allow distribution through app stores while maintaining GPL-3.0 compliance. Similar approach to [NextCloud's app store exception](https://github.com/nextcloud/ios/blob/master/COPYING.iOS).