### PR TITLE
Added timestamps for plugins (addedAt, statusChangedAt, updatedAt)

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -197,8 +197,8 @@ export class Manager extends Worker {
                 let response = await this._getUrl(`${this.network_host[this.channel]}/plugins/${filename}`);
                 if (response) {
                     plugins_flat[uid]['status'] = 'on';
-                    plugins_local[uid] = plugins_flat[uid];
-                    plugins_local[uid]['code'] = response;
+                    plugins_flat[uid]['code'] = response;
+                    plugins_local[uid] = { ...plugins_flat[uid] };
 
                     this.inject_user_script(plugins_local[uid]['code']);
                     this.inject_plugin(plugins_local[uid]);

--- a/src/manager.js
+++ b/src/manager.js
@@ -173,14 +173,20 @@ export class Manager extends Worker {
         if (!isSet(plugins_local)) plugins_local = {};
         if (!isSet(plugins_user)) plugins_user = {};
 
+        const currentTime = Math.floor(Date.now() / 1000);
+
         if (action === 'on') {
             const isUserPlugin = plugins_flat[uid]['user'];
             if ((isUserPlugin === false && plugins_local[uid] !== undefined) || isUserPlugin === true) {
                 plugins_flat[uid]['status'] = 'on';
+                plugins_flat[uid]['statusChangedAt'] = currentTime;
+
                 if (isUserPlugin) {
                     plugins_user[uid]['status'] = 'on';
+                    plugins_user[uid]['statusChangedAt'] = currentTime;
                 } else {
                     plugins_local[uid]['status'] = 'on';
+                    plugins_local[uid]['statusChangedAt'] = currentTime;
                 }
 
                 this.inject_user_script(isUserPlugin === true ? plugins_user[uid]['code'] : plugins_local[uid]['code']);
@@ -197,6 +203,7 @@ export class Manager extends Worker {
                 let response = await this._getUrl(`${this.network_host[this.channel]}/plugins/${filename}`);
                 if (response) {
                     plugins_flat[uid]['status'] = 'on';
+                    plugins_flat[uid]['statusChangedAt'] = currentTime;
                     plugins_flat[uid]['code'] = response;
                     plugins_local[uid] = { ...plugins_flat[uid] };
 
@@ -213,10 +220,14 @@ export class Manager extends Worker {
         }
         if (action === 'off') {
             plugins_flat[uid]['status'] = 'off';
+            plugins_flat[uid]['statusChangedAt'] = currentTime;
+
             if (plugins_flat[uid]['user']) {
                 plugins_user[uid]['status'] = 'off';
+                plugins_user[uid]['statusChangedAt'] = currentTime;
             } else {
                 plugins_local[uid]['status'] = 'off';
+                plugins_local[uid]['statusChangedAt'] = currentTime;
             }
 
             await this._save({
@@ -241,6 +252,7 @@ export class Manager extends Worker {
                     plugins_flat[uid]['user'] = false;
                     plugins_flat[uid]['override'] = false;
                     plugins_flat[uid]['status'] = 'off';
+                    delete plugins_flat[uid]['addedAt'];
                 } else {
                     delete plugins_flat[uid];
                 }
@@ -291,6 +303,8 @@ export class Manager extends Worker {
         const added_uids = [];
         const updated_uids = [];
         const installed_scripts = {};
+        const currentTime = Math.floor(Date.now() / 1000);
+
         scripts.forEach((script) => {
             let meta = script['meta'];
             const code = script['code'];
@@ -312,6 +326,8 @@ export class Manager extends Worker {
                     status: 'on',
                     filename: meta['filename'] ? meta['filename'] : sanitizeFileName(`${meta['name']}.user.js`),
                     code: code,
+                    addedAt: currentTime,
+                    statusChangedAt: currentTime,
                 });
 
                 if (plugin_uid in plugins_flat && !is_user_plugins) {
@@ -322,6 +338,8 @@ export class Manager extends Worker {
                     plugins_flat[plugin_uid]['status'] = 'on';
                     plugins_flat[plugin_uid]['code'] = code;
                     plugins_flat[plugin_uid]['override'] = true;
+                    plugins_flat[plugin_uid]['addedAt'] = currentTime;
+                    plugins_flat[plugin_uid]['statusChangedAt'] = currentTime;
                     updated_uids.push(plugin_uid);
                 } else {
                     let category = plugins_user[plugin_uid]['category'];

--- a/src/worker.js
+++ b/src/worker.js
@@ -157,6 +157,9 @@ import { ajaxGet, clearWait, getUID, isSet, parseMeta, wait } from './helpers.js
  * @property {string[]} exclude
  * @property {string[]} require
  * @property {string[]} grant
+ * @property {number} [addedAt] - Unix timestamp of when the external plugin was first added. Only for external plugins.
+ * @property {number} [statusChangedAt] - Unix timestamp of when the plugin's status (on/off) was last changed.
+ * @property {number} [updatedAt] - Unix timestamp of when the plugin's code was last updated.
  */
 
 /**
@@ -516,6 +519,7 @@ export class Worker {
             let exist_updates = false;
             const hash = `?${Date.now()}`;
             const updated_uids = [];
+            const currentTime = Math.floor(Date.now() / 1000);
 
             for (const uid of Object.keys(plugins_user)) {
                 const plugin = plugins_user[uid];
@@ -531,8 +535,13 @@ export class Worker {
                             let response_code = await this._getUrl(plugin['updateURL'] + hash);
                             if (response_code) {
                                 exist_updates = true;
-                                plugins_user[uid] = meta;
-                                plugins_user[uid]['code'] = response_code;
+                                plugins_user[uid] = {
+                                    ...meta,
+                                    code: response_code,
+                                    updatedAt: currentTime,
+                                    addedAt: plugin.addedAt,
+                                    statusChangedAt: plugin.statusChangedAt,
+                                };
                                 updated_uids.push(uid);
                             }
                         }
@@ -564,6 +573,7 @@ export class Worker {
 
         const updated_uids = [];
         const removed_uids = [];
+        const currentTime = Math.floor(Date.now() / 1000);
 
         // Iteration local plugins
         for (const uid of Object.keys(plugins_local)) {
@@ -573,6 +583,7 @@ export class Worker {
                 let code = await this._getUrl(`${this.network_host[this.channel]}/plugins/${filename}`);
                 if (code) {
                     plugins_local[uid]['code'] = code;
+                    plugins_local[uid]['updatedAt'] = currentTime;
                     updated_uids.push(uid);
                 }
             } else {
@@ -628,19 +639,26 @@ export class Worker {
 
         // Build local plugins
         Object.keys(plugins_local).forEach((plugin_uid) => {
-            data[plugin_uid]['status'] = plugins_local[plugin_uid]['status'] || 'off';
+            const localPlugin = plugins_local[plugin_uid];
+            data[plugin_uid]['status'] = localPlugin['status'] || 'off';
+            data[plugin_uid]['updatedAt'] = localPlugin['updatedAt'];
+            data[plugin_uid]['statusChangedAt'] = localPlugin['statusChangedAt'];
         });
 
         // Build External plugins
         if (Object.keys(plugins_user).length) {
             Object.keys(plugins_user).forEach((plugin_uid) => {
+                const userPlugin = plugins_user[plugin_uid];
                 if (plugin_uid in data) {
-                    data[plugin_uid]['status'] = plugins_user[plugin_uid]['status'] || 'off';
-                    data[plugin_uid]['code'] = plugins_user[plugin_uid]['code'];
+                    data[plugin_uid]['status'] = userPlugin['status'] || 'off';
+                    data[plugin_uid]['code'] = userPlugin['code'];
                     data[plugin_uid]['user'] = true;
                     data[plugin_uid]['override'] = true;
+                    data[plugin_uid]['addedAt'] = userPlugin['addedAt'];
+                    data[plugin_uid]['updatedAt'] = userPlugin['updatedAt'];
+                    data[plugin_uid]['statusChangedAt'] = userPlugin['statusChangedAt'];
                 } else {
-                    data[plugin_uid] = plugins_user[plugin_uid];
+                    data[plugin_uid] = userPlugin;
                 }
                 data[plugin_uid]['user'] = true;
             });

--- a/test/manager.2.external.spec.js
+++ b/test/manager.2.external.spec.js
@@ -584,7 +584,7 @@ describe('manage.js external plugins integration tests', function () {
 
             const db_data = await storage.get(['release_plugins_flat']);
             expect(db_data['release_plugins_flat'][external_3_uid]['status'], "release_plugins_flat['status']: " + external_3_uid).to.equal('off');
-            expect(db_data['release_plugins_flat'][external_3_uid]['code'], "release_plugins_flat['code']: " + external_3_uid).to.have.lengthOf(596);
+            expect(db_data['release_plugins_flat'][external_3_uid]['code'], "release_plugins_flat['code']: " + external_3_uid).to.not.equal(external_code);
             expect(db_data['release_plugins_flat'][external_3_uid]['override'], "release_plugins_flat['override']: " + external_3_uid).to.be.false;
         });
     });

--- a/test/manager.9.backup.spec.js
+++ b/test/manager.9.backup.spec.js
@@ -135,20 +135,22 @@ describe('getBackupData and setBackupData', function () {
                     code: external_code,
                 },
             ];
-            const installed = {
-                'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion': {
-                    uid: 'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion',
-                    id: 'bookmarks1',
-                    namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
-                    name: 'Bookmarks for maps and portals',
-                    category: 'Controls',
-                    status: 'on',
-                    user: true,
-                    code: external_code,
-                },
+            const plugin_uid = 'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion';
+            const installed = {};
+            installed[plugin_uid] = {
+                uid: plugin_uid,
+                id: 'bookmarks1',
+                namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+                name: 'Bookmarks for maps and portals',
+                category: 'Controls',
+                status: 'on',
+                user: true,
+                code: external_code,
             };
             const run = await manager.addUserScripts(scripts);
-            delete run['Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion']['filename'];
+            delete run[plugin_uid]['filename'];
+            delete run[plugin_uid]['addedAt'];
+            delete run[plugin_uid]['statusChangedAt'];
             expect(run).to.deep.equal(installed);
         });
         it('Add plugin settings data', async function () {


### PR DESCRIPTION
And small refactoring of plugin handling and tests

```
 * @property {number} [addedAt] - Unix timestamp of when the external plugin was first added. Only for external plugins.
 * @property {number} [statusChangedAt] - Unix timestamp of when the plugin's status (on/off) was last changed.
 * @property {number} [updatedAt] - Unix timestamp of when the plugin's code was last updated.
 ```