### PR TITLE
Replace storage-backed plugin/category state with on-demand computed view

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,51 @@ import { Manager } from 'lib-iitc-manager';
 const manager = new Manager({
     storage: browser.storage.local,
     message: (message, args) => {
-        console.log("Message for user:");
-        console.log(message+", args: "+args);
+        console.log("Message for user:", message, args);
     },
     progressbar: is_show => {
-        if (is_show) {
-            console.log("Show progress bar");
-        } else {
-            console.log("Hide progress bar");
-        }
+        console.log(is_show ? "Show progress bar" : "Hide progress bar");
     },
     inject_plugin: plugin => {
-        console.log("Code of UserScript plugin for embedding in a page:");
-        console.log(plugin['code']);
-    }
+        console.log("Injecting plugin:", plugin.name);
+        console.log(plugin.code);
+    },
+    plugins_view_changed: ({ plugins, categories }) => {
+        // Called whenever the plugin set changes.
+        // plugins - merged view of all plugins (catalog + state + user overrides).
+        // categories - non-empty categories derived from plugins, sorted alphabetically.
+        console.log("Plugin list updated:", Object.keys(plugins).length, "plugins");
+        console.log("Categories:", Object.keys(categories));
+    },
 });
 
 manager.run().then();
 ```
 
-Example of use helpers:
+### Getting the current plugin list and categories
+
+```js
+const { plugins, categories } = await manager.getPluginsView();
+
+// plugins is a PluginDict - keyed by uid, each entry is a merged Plugin object.
+// Fields: uid, name, category, status ('on'/'off'), user, override, code, ...
+for (const [uid, plugin] of Object.entries(plugins)) {
+    console.log(uid, plugin.status, plugin.user ? '(user)' : '');
+}
+
+// categories is a CategoryViewDict - keyed by category name, sorted alphabetically.
+// Each entry: { name: string, isNew: boolean }
+// isNew is true if any plugin in that category was added within new_plugin_threshold seconds.
+for (const [name, cat] of Object.entries(categories)) {
+    console.log(name, cat.isNew ? '(new)' : '');
+}
+```
+
+### Reacting to plugin list changes
+
+Pass `plugins_view_changed` in the config (see above), or poll with `getPluginsView()` as needed.
+
+### Example of use helpers
 
 ```js
 import { getUniqId } from "lib-iitc-manager";
@@ -48,11 +73,15 @@ const uniqId = getUniqId("tmp");
 
 [See more in documentation](https://iitc-ce.github.io/lib-iitc-manager/)
 
+## Migrating from v1
+
+### `plugins_flat` and `${channel}_categories` removed
+
+`${channel}_plugins_flat` and `${channel}_categories` is no longer written to storage. Plugins and categories are computed on demand from the plugin set and returned as part of `PluginsView`.
+
 ## License
 
 lib-iitc-manager is licensed under [GNU General Public License v3.0 (GPL-3.0)](/LICENSE).
 For distribution through application stores (Apple App Store, Google Play Store, and others),
 please refer to the [COPYING.STORE](/COPYING.STORE) file, which provides an exception for the application store
 distribution requirements while maintaining GPL-3.0 compliance for the source code.
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,9 @@ export type {
   PluginMeta,
   Plugin,
   PluginDict,
+  CategoryView,
+  CategoryViewDict,
+  PluginsView,
   EmptyObject,
   PluginEventType,
   PluginEventData,
@@ -59,8 +62,6 @@ export type {
   FetchResourceResult,
   UserScript,
   BackupData,
-  CategoryInfo,
-  CategoryDict,
   MetaJsonResponse,
   IngressDomain,
 } from './types.js';

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -37,14 +37,12 @@ export class Manager extends Worker {
 
     // Ensure minimal data structures exist for new channel
     const newChannelData = await this.storage.get([
-      `${channel}_plugins_flat`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
 
     // Initialize missing structures if needed
     const updates: StorageData = {};
-    if (!newChannelData[`${channel}_plugins_flat`]) updates[`${channel}_plugins_flat`] = {};
     if (!newChannelData[`${channel}_plugins_local`]) updates[`${channel}_plugins_local`] = {};
     if (!newChannelData[`${channel}_plugins_user`]) updates[`${channel}_plugins_user`] = {};
 
@@ -236,12 +234,12 @@ export class Manager extends Worker {
   async managePlugin(uid: string, action: 'on' | 'off' | 'delete'): Promise<void> {
     const channel = this.channel;
     const local = await this.storage.get([
-      `${channel}_plugins_flat`,
+      `${channel}_plugins_catalog`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
 
-    const plugins_flat = local[`${channel}_plugins_flat`] as PluginDict;
+    const plugins_catalog = (local[`${channel}_plugins_catalog`] || {}) as PluginDict;
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
     let plugins_user = local[`${channel}_plugins_user`] as PluginDict;
 
@@ -249,13 +247,10 @@ export class Manager extends Worker {
     if (!isSet(plugins_user)) plugins_user = {};
 
     const currentTime = Math.floor(Date.now() / 1000);
+    const isUserPlugin = uid in plugins_user;
 
     if (action === 'on') {
-      const isUserPlugin = plugins_flat[uid]['user'];
-      if ((isUserPlugin === false && plugins_local[uid] !== undefined) || isUserPlugin === true) {
-        plugins_flat[uid]['status'] = 'on';
-        plugins_flat[uid]['statusChangedAt'] = currentTime;
-
+      if (isUserPlugin || plugins_local[uid] !== undefined) {
         if (isUserPlugin) {
           plugins_user[uid]['status'] = 'on';
           plugins_user[uid]['statusChangedAt'] = currentTime;
@@ -264,79 +259,58 @@ export class Manager extends Worker {
           plugins_local[uid]['statusChangedAt'] = currentTime;
         }
 
-        const pluginToInject = isUserPlugin === true ? plugins_user[uid] : plugins_local[uid];
+        const pluginToInject = isUserPlugin ? plugins_user[uid] : plugins_local[uid];
         this._injectWithGmApi(pluginToInject);
 
-        await this._save(channel, {
-          plugins_flat: plugins_flat,
-          plugins_local: plugins_local,
-          plugins_user: plugins_user,
-        });
+        await this._save(channel, { plugins_local, plugins_user });
         await this._sendPluginsEvent(channel, [uid], 'add');
       } else {
-        const filename = plugins_flat[uid]['filename'];
+        const filename = plugins_catalog[uid]?.['filename'];
         const result = await this._getUrl(`${this.network_host[channel]}/plugins/${filename}`);
         if (result.data) {
-          plugins_flat[uid]['status'] = 'on';
-          plugins_flat[uid]['statusChangedAt'] = currentTime;
-          plugins_flat[uid]['code'] = result.data as string;
-          plugins_local[uid] = { ...plugins_flat[uid] };
+          plugins_local[uid] = {
+            ...plugins_catalog[uid],
+            status: 'on',
+            statusChangedAt: currentTime,
+            code: result.data as string,
+          };
 
           this._injectWithGmApi(plugins_local[uid]);
 
-          await this._save(channel, {
-            plugins_flat: plugins_flat,
-            plugins_local: plugins_local,
-          });
+          await this._save(channel, { plugins_local });
           await this._sendPluginsEvent(channel, [uid], 'add');
         }
       }
     }
     if (action === 'off') {
-      plugins_flat[uid]['status'] = 'off';
-      plugins_flat[uid]['statusChangedAt'] = currentTime;
-
-      if (plugins_flat[uid]['user']) {
+      if (isUserPlugin) {
         plugins_user[uid]['status'] = 'off';
         plugins_user[uid]['statusChangedAt'] = currentTime;
-      } else {
+      } else if (plugins_local[uid]) {
         plugins_local[uid]['status'] = 'off';
         plugins_local[uid]['statusChangedAt'] = currentTime;
       }
 
-      await this._save(channel, {
-        plugins_flat: plugins_flat,
-        plugins_local: plugins_local,
-        plugins_user: plugins_user,
-      });
+      await this._save(channel, { plugins_local, plugins_user });
       await this._sendPluginsEvent(channel, [uid], 'remove');
     }
     if (action === 'delete') {
       if (uid === this.iitc_main_script_uid) {
-        await this._save(channel, {
-          iitc_core_user: {},
-        });
+        await this._save(channel, { iitc_core_user: {} });
         await this._sendPluginsEvent(channel, [uid], 'update');
       } else {
-        const isEnabled = plugins_flat[uid]['status'] === 'on';
-        if (plugins_flat[uid]['override']) {
-          if (plugins_local[uid] !== undefined) {
-            plugins_flat[uid] = { ...plugins_local[uid] };
-          }
-          plugins_flat[uid]['user'] = false;
-          plugins_flat[uid]['override'] = false;
-          plugins_flat[uid]['status'] = 'off';
-          delete plugins_flat[uid]['addedAt'];
-        } else {
-          delete plugins_flat[uid];
-        }
-        delete plugins_user[uid];
+        const isEnabled = isUserPlugin
+          ? plugins_user[uid]['status'] === 'on'
+          : plugins_local[uid]?.['status'] === 'on';
 
-        await this._save(channel, {
-          plugins_flat: plugins_flat,
-          plugins_local: plugins_local,
-          plugins_user: plugins_user,
-        });
+        delete plugins_user[uid];
+        // If it was overriding a local (catalog) plugin, reset local status to off
+        if (plugins_local[uid]) {
+          plugins_local[uid]['status'] = 'off';
+          delete plugins_local[uid]['statusChangedAt'];
+        }
+
+        await this._save(channel, { plugins_local, plugins_user });
         if (isEnabled) {
           await this._sendPluginsEvent(channel, [uid], 'remove');
         }
@@ -355,19 +329,18 @@ export class Manager extends Worker {
     const local = await this.storage.get([
       `${channel}_iitc_core_user`,
       `${channel}_categories`,
-      `${channel}_plugins_flat`,
+      `${channel}_plugins_catalog`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
 
     let iitc_core_user = local[`${channel}_iitc_core_user`] as Plugin | undefined;
     let categories = local[`${channel}_categories`] as CategoryDict;
-    let plugins_flat = local[`${channel}_plugins_flat`] as PluginDict;
+    const plugins_catalog = (local[`${channel}_plugins_catalog`] || {}) as PluginDict;
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
     let plugins_user = local[`${channel}_plugins_user`] as PluginDict;
 
     if (!isSet(categories)) categories = {};
-    if (!isSet(plugins_flat)) plugins_flat = {};
     if (!isSet(plugins_local)) plugins_local = {};
     if (!isSet(plugins_user)) plugins_user = {};
 
@@ -403,17 +376,24 @@ export class Manager extends Worker {
           statusChangedAt: currentTime,
         }) as Plugin;
 
-        if (plugin_uid in plugins_flat && !is_user_plugins) {
-          if (plugin_uid in plugins_local && plugins_flat[plugin_uid]['status'] !== 'off') {
+        if (plugin_uid in plugins_catalog && !is_user_plugins) {
+          // Override existing catalog plugin: disable its local copy if enabled
+          if (plugins_local[plugin_uid] && plugins_local[plugin_uid]['status'] !== 'off') {
             plugins_local[plugin_uid]['status'] = 'off';
           }
-
-          plugins_flat[plugin_uid]['status'] = 'on';
-          plugins_flat[plugin_uid]['code'] = code;
-          plugins_flat[plugin_uid]['override'] = true;
-          plugins_flat[plugin_uid]['addedAt'] = currentTime;
-          plugins_flat[plugin_uid]['statusChangedAt'] = currentTime;
           updated_uids.push(plugin_uid);
+          // Return merged catalog+user view with override flag (mirrors _computePluginsView)
+          const catalogEntry = plugins_catalog[plugin_uid];
+          const userEntry = plugins_user[plugin_uid];
+          installed_scripts[plugin_uid] = {
+            ...catalogEntry,
+            status: userEntry.status || 'off',
+            code: userEntry.code,
+            user: true,
+            override: true,
+            addedAt: userEntry.addedAt,
+            statusChangedAt: userEntry.statusChangedAt,
+          } as Plugin;
         } else {
           let category = plugins_user[plugin_uid]['category'];
           if (category === undefined) {
@@ -426,18 +406,15 @@ export class Manager extends Worker {
               description: '',
             };
           }
-          plugins_flat[plugin_uid] = { ...plugins_user[plugin_uid] };
           added_uids.push(plugin_uid);
+          installed_scripts[plugin_uid] = { ...plugins_user[plugin_uid], user: true };
         }
-        plugins_flat[plugin_uid]['user'] = true;
-        installed_scripts[plugin_uid] = plugins_flat[plugin_uid];
       }
     });
 
     await this._save(channel, {
       iitc_core_user: iitc_core_user,
       categories: categories,
-      plugins_flat: plugins_flat,
       plugins_local: plugins_local,
       plugins_user: plugins_user,
     });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -10,11 +10,11 @@ import type {
   Channel,
   Plugin,
   PluginDict,
+  PluginsView,
   StorageData,
   BackupParams,
   BackupData,
   UserScript,
-  CategoryDict,
 } from './types.js';
 
 /**
@@ -102,10 +102,10 @@ export class Manager extends Worker {
   }
 
   /**
-   * Returns a merged view of all plugins for the current channel.
+   * Returns the merged view of all plugins and categories for the current channel.
    * Combines server catalog with local installation state and user overrides.
    */
-  async getPlugins(): Promise<PluginDict> {
+  async getPluginsView(): Promise<PluginsView> {
     const channel = this.channel;
     const storage = await this.storage.get([
       `${channel}_plugins_catalog`,
@@ -121,8 +121,8 @@ export class Manager extends Worker {
   }
 
   _emitPluginsChanged(): void {
-    if (!this.plugins_changed) return;
-    this.getPlugins().then(plugins => this.plugins_changed!(plugins));
+    if (!this.plugins_view_changed) return;
+    this.getPluginsView().then(view => this.plugins_view_changed!(view));
   }
 
   /**
@@ -142,7 +142,11 @@ export class Manager extends Worker {
     const plugins_local = (storage[`${channel}_plugins_local`] || {}) as PluginDict;
     const plugins_user = (storage[`${channel}_plugins_user`] || {}) as PluginDict;
 
-    const all_plugins = this._computePluginsView(plugins_catalog, plugins_local, plugins_user);
+    const { plugins: all_plugins } = this._computePluginsView(
+      plugins_catalog,
+      plugins_local,
+      plugins_user
+    );
 
     const enabled_plugins: PluginDict = {};
 
@@ -328,19 +332,16 @@ export class Manager extends Worker {
     const channel = this.channel;
     const local = await this.storage.get([
       `${channel}_iitc_core_user`,
-      `${channel}_categories`,
       `${channel}_plugins_catalog`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
 
     let iitc_core_user = local[`${channel}_iitc_core_user`] as Plugin | undefined;
-    let categories = local[`${channel}_categories`] as CategoryDict;
     const plugins_catalog = (local[`${channel}_plugins_catalog`] || {}) as PluginDict;
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
     let plugins_user = local[`${channel}_plugins_user`] as PluginDict;
 
-    if (!isSet(categories)) categories = {};
     if (!isSet(plugins_local)) plugins_local = {};
     if (!isSet(plugins_user)) plugins_user = {};
 
@@ -395,16 +396,8 @@ export class Manager extends Worker {
             statusChangedAt: userEntry.statusChangedAt,
           } as Plugin;
         } else {
-          let category = plugins_user[plugin_uid]['category'];
-          if (category === undefined) {
-            category = 'Misc';
-            plugins_user[plugin_uid]['category'] = category;
-          }
-          if (!(category in categories)) {
-            categories[category] = {
-              name: category,
-              description: '',
-            };
+          if (plugins_user[plugin_uid]['category'] === undefined) {
+            plugins_user[plugin_uid]['category'] = 'Misc';
           }
           added_uids.push(plugin_uid);
           installed_scripts[plugin_uid] = { ...plugins_user[plugin_uid], user: true };
@@ -414,7 +407,6 @@ export class Manager extends Worker {
 
     await this._save(channel, {
       iitc_core_user: iitc_core_user,
-      categories: categories,
       plugins_local: plugins_local,
       plugins_user: plugins_user,
     });
@@ -431,8 +423,8 @@ export class Manager extends Worker {
    * @param uid - Plugin UID.
    */
   async getPluginInfo(uid: string): Promise<Plugin | null> {
-    const all_plugins = await this.getPlugins();
-    return all_plugins[uid] ?? null;
+    const { plugins } = await this.getPluginsView();
+    return plugins[uid] ?? null;
   }
 
   /**

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -104,6 +104,30 @@ export class Manager extends Worker {
   }
 
   /**
+   * Returns a merged view of all plugins for the current channel.
+   * Combines server catalog with local installation state and user overrides.
+   */
+  async getPlugins(): Promise<PluginDict> {
+    const channel = this.channel;
+    const storage = await this.storage.get([
+      `${channel}_plugins_catalog`,
+      `${channel}_plugins_local`,
+      `${channel}_plugins_user`,
+    ]);
+
+    const plugins_catalog = (storage[`${channel}_plugins_catalog`] || {}) as PluginDict;
+    const plugins_local = (storage[`${channel}_plugins_local`] || {}) as PluginDict;
+    const plugins_user = (storage[`${channel}_plugins_user`] || {}) as PluginDict;
+
+    return this._computePluginsView(plugins_catalog, plugins_local, plugins_user);
+  }
+
+  _emitPluginsChanged(): void {
+    if (!this.plugins_changed) return;
+    this.getPlugins().then(plugins => this.plugins_changed!(plugins));
+  }
+
+  /**
    * Returns an object of all enabled plugins, including IITC core, with plugin UID as the key.
    */
   async getEnabledPlugins(): Promise<PluginDict> {
@@ -111,14 +135,16 @@ export class Manager extends Worker {
     const storage = await this.storage.get([
       `${channel}_iitc_core`,
       `${channel}_iitc_core_user`,
-      `${channel}_plugins_flat`,
+      `${channel}_plugins_catalog`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
 
-    const plugins_flat = (storage[`${channel}_plugins_flat`] || {}) as PluginDict;
+    const plugins_catalog = (storage[`${channel}_plugins_catalog`] || {}) as PluginDict;
     const plugins_local = (storage[`${channel}_plugins_local`] || {}) as PluginDict;
     const plugins_user = (storage[`${channel}_plugins_user`] || {}) as PluginDict;
+
+    const all_plugins = this._computePluginsView(plugins_catalog, plugins_local, plugins_user);
 
     const enabled_plugins: PluginDict = {};
 
@@ -148,11 +174,11 @@ export class Manager extends Worker {
       }
       enabled_plugins[this.iitc_main_script_uid] = iitc_script;
 
-      for (const uid in plugins_flat) {
-        if (plugins_flat[uid]['status'] === 'on') {
+      for (const uid in all_plugins) {
+        if (all_plugins[uid]['status'] === 'on') {
           // If the plugin is marked as 'user', use its 'user' version; otherwise, use its 'local' version
           enabled_plugins[uid] =
-            plugins_flat[uid]['user'] === true
+            all_plugins[uid]['user'] === true
               ? plugins_user[uid] || ({} as Plugin)
               : plugins_local[uid] || ({} as Plugin);
         }
@@ -428,11 +454,8 @@ export class Manager extends Worker {
    * @param uid - Plugin UID.
    */
   async getPluginInfo(uid: string): Promise<Plugin | null> {
-    const all_plugins = (await this.storage
-      .get([this.channel + '_plugins_flat'])
-      .then(data => data[this.channel + '_plugins_flat'])) as PluginDict | undefined;
-    if (all_plugins === undefined) return null;
-    return all_plugins[uid];
+    const all_plugins = await this.getPlugins();
+    return all_plugins[uid] ?? null;
   }
 
   /**

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -217,5 +217,6 @@ async function migration_0006(
     }
 
     storage_plugins_catalog[catalogKey] = catalog;
+    storage_plugins_flat[key] = null;
   }
 }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -13,7 +13,8 @@ type MigrationFn = (
   storage_plugins_user: StorageData,
   storage_misc: StorageData,
   update_check_interval: StorageData,
-  storage_plugins_catalog: StorageData
+  storage_plugins_catalog: StorageData,
+  storage_categories: StorageData
 ) => Promise<void>;
 
 const migrates: MigrationFn[] = [
@@ -42,6 +43,11 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
     'release_plugins_catalog',
     'beta_plugins_catalog',
     'custom_plugins_catalog',
+  ]);
+  const storage_categories = await storage.get([
+    'release_categories',
+    'beta_categories',
+    'custom_categories',
   ]);
   const storage_plugins_user = await storage.get([
     'release_plugins_user',
@@ -77,7 +83,8 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
         storage_plugins_user,
         storage_misc,
         update_check_interval,
-        storage_plugins_catalog
+        storage_plugins_catalog,
+        storage_categories
       );
       is_migrated = true;
     }
@@ -91,6 +98,7 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
     ...storage_plugins_user,
     ...storage_misc,
     ...update_check_interval,
+    ...storage_categories,
   });
   return is_migrated;
 }
@@ -196,7 +204,8 @@ async function migration_0006(
   _storage_plugins_user: StorageData,
   _storage_misc: StorageData,
   _update_check_interval: StorageData,
-  storage_plugins_catalog: StorageData
+  storage_plugins_catalog: StorageData,
+  storage_categories: StorageData
 ): Promise<void> {
   for (const key of Object.keys(storage_plugins_flat)) {
     if (!isSet(storage_plugins_flat[key])) continue;
@@ -218,5 +227,9 @@ async function migration_0006(
 
     storage_plugins_catalog[catalogKey] = catalog;
     storage_plugins_flat[key] = null;
+  }
+
+  for (const key of Object.keys(storage_categories)) {
+    storage_categories[key] = null;
   }
 }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -12,7 +12,8 @@ type MigrationFn = (
   storage_plugins_flat: StorageData,
   storage_plugins_user: StorageData,
   storage_misc: StorageData,
-  update_check_interval: StorageData
+  update_check_interval: StorageData,
+  storage_plugins_catalog: StorageData
 ) => Promise<void>;
 
 const migrates: MigrationFn[] = [
@@ -21,6 +22,7 @@ const migrates: MigrationFn[] = [
   migration_0003,
   migration_0004,
   migration_0005,
+  migration_0006,
 ];
 
 export async function migrate(storage: StorageAPI): Promise<boolean> {
@@ -35,6 +37,11 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
     'custom_plugins_flat',
     'test_plugins_flat',
     'local_plugins_flat',
+  ]);
+  const storage_plugins_catalog = await storage.get([
+    'release_plugins_catalog',
+    'beta_plugins_catalog',
+    'custom_plugins_catalog',
   ]);
   const storage_plugins_user = await storage.get([
     'release_plugins_user',
@@ -69,7 +76,8 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
         storage_plugins_flat,
         storage_plugins_user,
         storage_misc,
-        update_check_interval
+        update_check_interval,
+        storage_plugins_catalog
       );
       is_migrated = true;
     }
@@ -79,6 +87,7 @@ export async function migrate(storage: StorageAPI): Promise<boolean> {
   await storage.set({
     ...storage_iitc_code,
     ...storage_plugins_flat,
+    ...storage_plugins_catalog,
     ...storage_plugins_user,
     ...storage_misc,
     ...update_check_interval,
@@ -168,5 +177,45 @@ async function migration_0005(
     if (interval !== 24 * 60 * 60) {
       update_check_interval[channel] = interval * 60 * 60;
     }
+  }
+}
+
+const RUNTIME_PLUGIN_FIELDS = [
+  'code',
+  'status',
+  'user',
+  'override',
+  'addedAt',
+  'statusChangedAt',
+  'updatedAt',
+];
+
+async function migration_0006(
+  _storage_iitc_code: StorageData,
+  storage_plugins_flat: StorageData,
+  _storage_plugins_user: StorageData,
+  _storage_misc: StorageData,
+  _update_check_interval: StorageData,
+  storage_plugins_catalog: StorageData
+): Promise<void> {
+  for (const key of Object.keys(storage_plugins_flat)) {
+    if (!isSet(storage_plugins_flat[key])) continue;
+
+    const flat = storage_plugins_flat[key] as StorageData;
+    const catalogKey = key.replace('_plugins_flat', '_plugins_catalog');
+    const catalog: StorageData = {};
+
+    for (const uid of Object.keys(flat)) {
+      const plugin = flat[uid] as StorageData;
+      const entry: StorageData = {};
+      for (const field of Object.keys(plugin)) {
+        if (!RUNTIME_PLUGIN_FIELDS.includes(field)) {
+          entry[field] = plugin[field];
+        }
+      }
+      catalog[uid] = entry;
+    }
+
+    storage_plugins_catalog[catalogKey] = catalog;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,33 @@ export interface PluginDict {
 }
 
 /**
+ * Computed view of a single plugin category.
+ */
+export interface CategoryView {
+  /** Category name. */
+  name: string;
+  /** True if this category contains a plugin added within the new_plugin_threshold window. */
+  isNew: boolean;
+}
+
+/**
+ * Dictionary of computed category views, sorted alphabetically by name.
+ */
+export interface CategoryViewDict {
+  [name: string]: CategoryView;
+}
+
+/**
+ * Combined view returned by getPluginsView() and the plugins_view_changed callback.
+ */
+export interface PluginsView {
+  /** Merged view of all plugins (catalog + local state + user overrides). */
+  plugins: PluginDict;
+  /** Non-empty categories derived from the current plugin set, sorted alphabetically. */
+  categories: CategoryViewDict;
+}
+
+/**
  * Empty object, used to represent removed plugins in events.
  */
 export type EmptyObject = Record<string, never>;
@@ -228,13 +255,20 @@ export interface ManagerConfig {
   plugin_event?: (event: PluginEventData) => void;
 
   /**
-   * Called whenever the full plugin list changes - after catalog updates,
-   * plugin enable/disable, user script additions/removals, or channel switches.
-   * Receives the current merged view of all plugins (catalog + local state + user overrides).
-   *
-   * @param plugins - Current merged plugin dictionary.
+   * Threshold in seconds for the isNew flag on categories.
+   * A category is marked as new if it contains a plugin with addedAt within this window.
+   * Default: 3600 (1 hour).
    */
-  plugins_changed?: (plugins: PluginDict) => void;
+  new_plugin_threshold?: number;
+
+  /**
+   * Called whenever the plugin set changes - after catalog updates, plugin enable/disable,
+   * user script additions/removals, or channel switches.
+   * Receives the current merged view of all plugins and computed categories.
+   *
+   * @param view - Current plugins and categories view.
+   */
+  plugins_view_changed?: (view: PluginsView) => void;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,15 @@ export interface ManagerConfig {
    * @param event - An object containing the event type and a mapping of plugin data.
    */
   plugin_event?: (event: PluginEventData) => void;
+
+  /**
+   * Called whenever the full plugin list changes - after catalog updates,
+   * plugin enable/disable, user script additions/removals, or channel switches.
+   * Receives the current merged view of all plugins (catalog + local state + user overrides).
+   *
+   * @param plugins - Current merged plugin dictionary.
+   */
+  plugins_changed?: (plugins: PluginDict) => void;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -308,11 +308,7 @@ export class Worker {
     const p_plugins = async () => {
       plugins_local = await this._updateLocalPlugins(channel, plugins_flat, plugins_local);
 
-      plugins_flat = this._rebuildingArrayCategoriesPlugins(
-        plugins_flat,
-        plugins_local,
-        plugins_user
-      );
+      plugins_flat = this._computePluginsView(plugins_flat, plugins_local, plugins_user);
       await this._save(channel, {
         iitc_version: response['iitc_version'],
         last_modified: last_modified,
@@ -539,14 +535,14 @@ export class Worker {
   }
 
   /**
-   * Rebuilds the plugins array maintaining proper isolation between channels.
+   * Computes a merged view of all plugins from the three sources
    *
    * @param raw_plugins - Dictionary of plugins downloaded from the server.
    * @param plugins_local - Dictionary of installed plugins from IITC-CE distribution.
    * @param plugins_user - Dictionary of external UserScripts.
    * @internal
    */
-  _rebuildingArrayCategoriesPlugins(
+  _computePluginsView(
     raw_plugins: PluginDict,
     plugins_local: PluginDict,
     plugins_user: PluginDict

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -142,6 +142,7 @@ export class Worker {
           'iitc_core',
           'iitc_core_user',
           'categories',
+          'plugins_catalog',
           'plugins_flat',
           'plugins_local',
           'plugins_user',
@@ -282,6 +283,7 @@ export class Worker {
     const response = result.data as MetaJsonResponse;
     const last_modified = result.version;
 
+    const plugins_catalog = this._getPluginsCatalog(response);
     let plugins_flat = this._getPluginsFlat(response);
     let categories = this._getCategories(response);
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
@@ -313,6 +315,7 @@ export class Worker {
         iitc_version: response['iitc_version'],
         last_modified: last_modified,
         categories: categories,
+        plugins_catalog: plugins_catalog,
         plugins_flat: plugins_flat,
         plugins_local: plugins_local,
         plugins_user: plugins_user,
@@ -339,6 +342,33 @@ export class Worker {
     });
 
     return categories;
+  }
+
+  /**
+   * Converts a list of categories with plugins into a flat catalog dictionary.
+   * Contains only server-side metadata fields - no runtime state (status, code, user, etc.).
+   *
+   * @param data - Data from received meta.json file.
+   * @internal
+   */
+  _getPluginsCatalog(data: MetaJsonResponse): PluginDict {
+    if (!('categories' in data)) return {};
+    const plugins: PluginDict = {};
+    const categories = data['categories'];
+
+    Object.keys(categories).forEach(cat => {
+      if (cat === 'Obsolete' || cat === 'Deleted') return;
+
+      if ('plugins' in categories[cat] && categories[cat].plugins) {
+        Object.keys(categories[cat].plugins!).forEach(id => {
+          const plugin = { ...(categories[cat].plugins![id] as unknown as Plugin) };
+          plugin['uid'] = getUID(plugin)!;
+          plugin['category'] = cat;
+          plugins[plugin['uid']] = plugin;
+        });
+      }
+    });
+    return plugins;
   }
 
   /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,13 +11,14 @@ import type {
   NetworkHost,
   Plugin,
   PluginDict,
+  PluginsView,
+  CategoryViewDict,
   PluginEventType,
   PluginEventData,
   UpdateType,
   RequestVariant,
   FetchResourceOptions,
   FetchResourceResult,
-  CategoryDict,
   MetaJsonResponse,
 } from './types.js';
 
@@ -46,7 +47,8 @@ export class Worker {
   inject_user_script: (code: string) => void;
   inject_plugin: (plugin: Plugin) => void;
   plugin_event: (event: PluginEventData) => void;
-  plugins_changed?: (plugins: PluginDict) => void;
+  plugins_view_changed?: (view: PluginsView) => void;
+  new_plugin_threshold: number;
 
   /**
    * Creates an instance of Manager class with the specified parameters
@@ -73,7 +75,8 @@ export class Worker {
     this.plugin_event = this.config.plugin_event || function () {};
     this.gm_api = this.config.gm_api;
     this.source_url_prefix = this.config.source_url_prefix || '';
-    this.plugins_changed = this.config.plugins_changed;
+    this.plugins_view_changed = this.config.plugins_view_changed;
+    this.new_plugin_threshold = this.config.new_plugin_threshold ?? 3600;
 
     this.is_initialized = false;
     this._init().then();
@@ -143,7 +146,6 @@ export class Worker {
           'last_modified',
           'iitc_core',
           'iitc_core_user',
-          'categories',
           'plugins_catalog',
           'plugins_local',
           'plugins_user',
@@ -156,13 +158,7 @@ export class Worker {
     });
     await this.storage.set(data);
 
-    const pluginsKeys = [
-      'plugins_catalog',
-      'plugins_local',
-      'plugins_user',
-      'categories',
-      'channel',
-    ];
+    const pluginsKeys = ['plugins_catalog', 'plugins_local', 'plugins_user', 'channel'];
     if (Object.keys(options).some(k => pluginsKeys.includes(k)) && channel === this.channel) {
       this._emitPluginsChanged();
     }
@@ -302,12 +298,10 @@ export class Worker {
     const last_modified = result.version;
 
     const plugins_catalog = this._getPluginsCatalog(response);
-    let categories = this._getCategories(response);
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
     let plugins_user = local[`${channel}_plugins_user`] as PluginDict;
 
     if (!isSet(plugins_user)) plugins_user = {};
-    categories = this._rebuildingCategories(categories, plugins_user);
 
     const p_iitc = async () => {
       const result = await this._getUrl(
@@ -329,7 +323,6 @@ export class Worker {
       await this._save(channel, {
         iitc_version: response['iitc_version'],
         last_modified: last_modified,
-        categories: categories,
         plugins_catalog: plugins_catalog,
         plugins_local: plugins_local,
         plugins_user: plugins_user,
@@ -337,25 +330,6 @@ export class Worker {
     };
 
     await Promise.all([p_iitc, p_plugins].map(fn => fn()));
-  }
-
-  /**
-   * Builds a dictionary from received meta.json file, in which it places names and descriptions of categories.
-   *
-   * @param data - Data from received meta.json file.
-   * @internal
-   */
-  _getCategories(data: MetaJsonResponse): CategoryDict {
-    if (!('categories' in data)) return {};
-    const categories = data['categories'];
-
-    Object.keys(categories).forEach(cat => {
-      if ('plugins' in categories[cat]) {
-        delete categories[cat]['plugins'];
-      }
-    });
-
-    return categories;
   }
 
   /**
@@ -527,32 +501,7 @@ export class Worker {
   }
 
   /**
-   * Updates categories by adding custom categories of external plugins.
-   *
-   * @param categories - Dictionary with names and descriptions of categories.
-   * @param plugins_user - Dictionary of external UserScripts.
-   * @internal
-   */
-  _rebuildingCategories(categories: CategoryDict, plugins_user: PluginDict): CategoryDict {
-    if (Object.keys(plugins_user).length) {
-      Object.keys(plugins_user).forEach(plugin_uid => {
-        let category = plugins_user[plugin_uid]['category'];
-        if (category === undefined) {
-          category = 'Misc';
-        }
-        if (!(category in categories)) {
-          categories[category] = {
-            name: category,
-            description: '',
-          };
-        }
-      });
-    }
-    return categories;
-  }
-
-  /**
-   * Computes a merged view of all plugins from the three sources
+   * Computes a merged view of all plugins and their categories from the three sources.
    *
    * @param raw_plugins - Dictionary of plugins downloaded from the server.
    * @param plugins_local - Dictionary of installed plugins from IITC-CE distribution.
@@ -563,7 +512,7 @@ export class Worker {
     raw_plugins: PluginDict,
     plugins_local: PluginDict,
     plugins_user: PluginDict
-  ): PluginDict {
+  ): PluginsView {
     if (!isSet(plugins_local)) plugins_local = {};
     if (!isSet(plugins_user)) plugins_user = {};
 
@@ -604,7 +553,24 @@ export class Worker {
       });
     }
 
-    return data;
+    // Derive categories from merged plugins: filter empty, mark isNew, sort alphabetically
+    const now = Math.floor(Date.now() / 1000);
+    const threshold = this.new_plugin_threshold;
+    const rawCategories: CategoryViewDict = {};
+    for (const plugin of Object.values(data)) {
+      const cat = plugin.category || 'Misc';
+      if (!(cat in rawCategories)) {
+        rawCategories[cat] = { name: cat, isNew: false };
+      }
+      if (plugin.addedAt && now - plugin.addedAt <= threshold) {
+        rawCategories[cat].isNew = true;
+      }
+    }
+    const categories: CategoryViewDict = Object.fromEntries(
+      Object.entries(rawCategories).sort(([a], [b]) => a.localeCompare(b))
+    );
+
+    return { plugins: data, categories };
   }
 
   /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -145,7 +145,6 @@ export class Worker {
           'iitc_core_user',
           'categories',
           'plugins_catalog',
-          'plugins_flat',
           'plugins_local',
           'plugins_user',
         ].indexOf(key) !== -1
@@ -246,7 +245,6 @@ export class Worker {
       `${channel}_update_check_interval`,
       `${channel}_last_modified`,
       `${channel}_categories`,
-      `${channel}_plugins_flat`,
       `${channel}_plugins_local`,
       `${channel}_plugins_user`,
     ]);
@@ -304,7 +302,6 @@ export class Worker {
     const last_modified = result.version;
 
     const plugins_catalog = this._getPluginsCatalog(response);
-    let plugins_flat = this._getPluginsFlat(response);
     let categories = this._getCategories(response);
     let plugins_local = local[`${channel}_plugins_local`] as PluginDict;
     let plugins_user = local[`${channel}_plugins_user`] as PluginDict;
@@ -328,15 +325,12 @@ export class Worker {
     };
 
     const p_plugins = async () => {
-      plugins_local = await this._updateLocalPlugins(channel, plugins_flat, plugins_local);
-
-      plugins_flat = this._computePluginsView(plugins_flat, plugins_local, plugins_user);
+      plugins_local = await this._updateLocalPlugins(channel, plugins_catalog, plugins_local);
       await this._save(channel, {
         iitc_version: response['iitc_version'],
         last_modified: last_modified,
         categories: categories,
         plugins_catalog: plugins_catalog,
-        plugins_flat: plugins_flat,
         plugins_local: plugins_local,
         plugins_user: plugins_user,
       });
@@ -383,33 +377,6 @@ export class Worker {
         Object.keys(categories[cat].plugins!).forEach(id => {
           const plugin = { ...(categories[cat].plugins![id] as unknown as Plugin) };
           plugin['uid'] = getUID(plugin)!;
-          plugin['category'] = cat;
-          plugins[plugin['uid']] = plugin;
-        });
-      }
-    });
-    return plugins;
-  }
-
-  /**
-   * Converting a list of categories with plugins inside into a flat structure.
-   *
-   * @param data - Data from received meta.json file.
-   * @internal
-   */
-  _getPluginsFlat(data: MetaJsonResponse): PluginDict {
-    if (!('categories' in data)) return {};
-    const plugins: PluginDict = {};
-    const categories = data['categories'];
-
-    Object.keys(categories).forEach(cat => {
-      if (cat === 'Obsolete' || cat === 'Deleted') return;
-
-      if ('plugins' in categories[cat] && categories[cat].plugins) {
-        Object.keys(categories[cat].plugins!).forEach(id => {
-          const plugin = categories[cat].plugins![id] as unknown as Plugin;
-          plugin['uid'] = getUID(plugin)!;
-          plugin['status'] = 'off';
           plugin['category'] = cat;
           plugins[plugin['uid']] = plugin;
         });
@@ -526,7 +493,7 @@ export class Worker {
    */
   async _updateLocalPlugins(
     channel: Channel,
-    plugins_flat: PluginDict,
+    plugins_catalog: PluginDict,
     plugins_local: PluginDict
   ): Promise<PluginDict> {
     // If no plugins installed
@@ -540,7 +507,7 @@ export class Worker {
     for (const uid of Object.keys(plugins_local)) {
       const filename = plugins_local[uid]['filename'];
 
-      if (filename && plugins_flat[uid]) {
+      if (filename && plugins_catalog[uid]) {
         const result = await this._getUrl(`${this.network_host[this.channel]}/plugins/${filename}`);
         if (result.data) {
           plugins_local[uid]['code'] = result.data as string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,6 +46,7 @@ export class Worker {
   inject_user_script: (code: string) => void;
   inject_plugin: (plugin: Plugin) => void;
   plugin_event: (event: PluginEventData) => void;
+  plugins_changed?: (plugins: PluginDict) => void;
 
   /**
    * Creates an instance of Manager class with the specified parameters
@@ -72,6 +73,7 @@ export class Worker {
     this.plugin_event = this.config.plugin_event || function () {};
     this.gm_api = this.config.gm_api;
     this.source_url_prefix = this.config.source_url_prefix || '';
+    this.plugins_changed = this.config.plugins_changed;
 
     this.is_initialized = false;
     this._init().then();
@@ -154,7 +156,25 @@ export class Worker {
       }
     });
     await this.storage.set(data);
+
+    const pluginsKeys = [
+      'plugins_catalog',
+      'plugins_local',
+      'plugins_user',
+      'categories',
+      'channel',
+    ];
+    if (Object.keys(options).some(k => pluginsKeys.includes(k)) && channel === this.channel) {
+      this._emitPluginsChanged();
+    }
   }
+
+  /**
+   * Fires the plugins_changed callback with the current merged plugin view.
+   * Overridden in Manager where getPlugins() is available.
+   * @internal
+   */
+  _emitPluginsChanged(): void {}
 
   /**
    * The method requests data from the specified URL.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -547,10 +547,13 @@ export class Worker {
     plugins_local: PluginDict,
     plugins_user: PluginDict
   ): PluginDict {
-    const data: PluginDict = { ...raw_plugins };
-
     if (!isSet(plugins_local)) plugins_local = {};
     if (!isSet(plugins_user)) plugins_user = {};
+
+    const data: PluginDict = {};
+    for (const [uid, plugin] of Object.entries(raw_plugins)) {
+      data[uid] = { ...plugin, status: 'off' };
+    }
 
     // Get valid UIDs for current channel to prevent cross-channel contamination
     const currentChannelPluginUIDs = new Set(Object.keys(data));

--- a/test/manager.1.build-in.spec.ts
+++ b/test/manager.1.build-in.spec.ts
@@ -67,10 +67,10 @@ describe('manage.js build-in plugins integration tests', function () {
       const run = await manager!.managePlugin(first_plugin_uid, 'on');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_local']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_local']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_local = db_data['release_plugins_local'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -81,14 +81,11 @@ describe('manage.js build-in plugins integration tests', function () {
         (plugins_local[first_plugin_uid] as StorageData)['status'],
         'release_plugins_local: ' + first_plugin_uid
       ).to.equal('on');
+      const all_plugins_1 = await manager!.getPlugins();
       expect(
-        (plugins_flat[first_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + first_plugin_uid
-      ).to.equal('on');
-      expect(
-        (plugins_flat[second_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + second_plugin_uid
-      ).to.equal('off');
+        all_plugins_1[second_plugin_uid]['status'],
+        'getPlugins(): ' + second_plugin_uid
+      ).to.not.equal('on');
     });
 
     it('Enable second plugin', async function () {
@@ -102,10 +99,10 @@ describe('manage.js build-in plugins integration tests', function () {
       const run = await manager!.managePlugin(second_plugin_uid, 'on');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_local']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_local']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_local = db_data['release_plugins_local'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -123,16 +120,6 @@ describe('manage.js build-in plugins integration tests', function () {
       expect(
         (plugins_local[second_plugin_uid] as StorageData)['status'],
         'release_plugins_local: ' + second_plugin_uid
-      ).to.equal('on');
-
-      expect(
-        (plugins_flat[first_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + first_plugin_uid
-      ).to.equal('on');
-
-      expect(
-        (plugins_flat[second_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + second_plugin_uid
       ).to.equal('on');
     });
 
@@ -147,10 +134,10 @@ describe('manage.js build-in plugins integration tests', function () {
       const run = await manager!.managePlugin(first_plugin_uid, 'off');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_local']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_local']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_local = db_data['release_plugins_local'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -168,16 +155,6 @@ describe('manage.js build-in plugins integration tests', function () {
       expect(
         (plugins_local[second_plugin_uid] as StorageData)['status'],
         'release_plugins_local: ' + second_plugin_uid
-      ).to.equal('on');
-
-      expect(
-        (plugins_flat[first_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + first_plugin_uid
-      ).to.equal('off');
-
-      expect(
-        (plugins_flat[second_plugin_uid] as StorageData)['status'],
-        'release_plugins_flat: ' + second_plugin_uid
       ).to.equal('on');
     });
 
@@ -252,10 +229,7 @@ describe('Delete external plugins - comprehensive tests', function () {
     await manager!.managePlugin(external_plugin_uid, 'delete');
 
     // Verify storage state
-    const storage_after = await manager!.storage.get([
-      'release_plugins_flat',
-      'release_plugins_user',
-    ]);
+    const storage_after = await manager!.storage.get(['release_plugins_user']);
 
     // Verify plugin was removed from user plugins
     expect(storage_after['release_plugins_user']).to.be.empty;
@@ -288,10 +262,7 @@ describe('Delete external plugins - comprehensive tests', function () {
     await manager!.managePlugin(external_plugin_uid, 'delete');
 
     // Verify storage state
-    const storage_after = await manager!.storage.get([
-      'release_plugins_flat',
-      'release_plugins_user',
-    ]);
+    const storage_after = await manager!.storage.get(['release_plugins_user']);
 
     // Verify plugin was removed from user plugins
     expect(storage_after['release_plugins_user']).to.be.empty;
@@ -321,29 +292,25 @@ describe('Delete external plugins - comprehensive tests', function () {
     await manager!.addUserScripts([override_plugin]);
 
     // Verify override flag is set before deletion
-    const storage_before = await manager!.storage.get(['release_plugins_flat']);
-    const flat_before = storage_before['release_plugins_flat'] as StorageData;
-    expect((flat_before[built_in_uid] as StorageData).override).to.be.true;
-    expect((flat_before[built_in_uid] as StorageData).user).to.be.true;
-    expect((flat_before[built_in_uid] as StorageData).status).to.equal('on');
+    const plugin_before = await manager!.getPluginInfo(built_in_uid);
+    expect(plugin_before!.override).to.be.true;
+    expect(plugin_before!.user).to.be.true;
+    expect(plugin_before!.status).to.equal('on');
 
     // Delete the plugin
     await manager!.managePlugin(built_in_uid, 'delete');
 
     // Verify storage state after deletion
-    const storage_after = await manager!.storage.get([
-      'release_plugins_flat',
-      'release_plugins_user',
-    ]);
+    const storage_after = await manager!.storage.get(['release_plugins_user']);
 
     // Verify plugin was removed from user plugins
     expect(storage_after['release_plugins_user']).to.be.empty;
 
-    const flat_after = storage_after['release_plugins_flat'] as StorageData;
+    const plugin_after = await manager!.getPluginInfo(built_in_uid);
     // Verify built-in plugin was restored to original state
-    expect((flat_after[built_in_uid] as StorageData).override).to.be.false;
-    expect((flat_after[built_in_uid] as StorageData).user).to.be.false;
-    expect((flat_after[built_in_uid] as StorageData).status).to.equal('off');
+    expect(plugin_after!.override).to.not.be.true;
+    expect(plugin_after!.user).to.not.be.true;
+    expect(plugin_after!.status).to.not.equal('on');
   });
 
   describe('Timestamps for built-in plugins', function () {
@@ -383,20 +350,15 @@ describe('Delete external plugins - comprehensive tests', function () {
       // Enable plugin
       await manager!.managePlugin(built_in_plugin_uid, 'on');
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_local']);
+      const db_data = await storage.get(['release_plugins_local']);
       const plugins_local = db_data['release_plugins_local'] as StorageData;
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
       const local_plugin = plugins_local[built_in_plugin_uid] as StorageData;
-      const flat_plugin = plugins_flat[built_in_plugin_uid] as StorageData;
 
-      // Check statusChangedAt set in both storages
+      // Check statusChangedAt set in local storage
       expect(local_plugin).to.have.property('statusChangedAt');
-      expect(flat_plugin).to.have.property('statusChangedAt');
-      expect(flat_plugin.statusChangedAt).to.equal(local_plugin.statusChangedAt);
 
-      // Should not have addedAt
+      // Should not have addedAt (built-in plugins don't have addedAt)
       expect(local_plugin).to.not.have.property('addedAt');
-      expect(flat_plugin).to.not.have.property('addedAt');
     });
 
     it('should update statusChangedAt when toggling built-in plugin', async function () {
@@ -413,17 +375,13 @@ describe('Delete external plugins - comprehensive tests', function () {
       // Disable plugin
       await manager!.managePlugin(built_in_plugin_uid, 'off');
 
-      const after = await storage.get(['release_plugins_flat', 'release_plugins_local']);
+      const after = await storage.get(['release_plugins_local']);
       const after_local = (after['release_plugins_local'] as StorageData)[
-        built_in_plugin_uid
-      ] as StorageData;
-      const after_flat = (after['release_plugins_flat'] as StorageData)[
         built_in_plugin_uid
       ] as StorageData;
 
       // Check statusChangedAt updated
       expect(after_local.statusChangedAt as number).to.be.above(initialStatusChangedAt);
-      expect(after_flat.statusChangedAt).to.equal(after_local.statusChangedAt);
     });
 
     it('should set updatedAt when updating built-in plugin', async function () {
@@ -436,16 +394,12 @@ describe('Delete external plugins - comprehensive tests', function () {
       // Force update check
       await manager!.checkUpdates(true);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_local']);
+      const db_data = await storage.get(['release_plugins_local']);
       const plugins_local = db_data['release_plugins_local'] as StorageData;
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
       const local_plugin = plugins_local[built_in_plugin_uid] as StorageData;
-      const flat_plugin = plugins_flat[built_in_plugin_uid] as StorageData;
 
       // Check updatedAt is set
       expect(local_plugin).to.have.property('updatedAt');
-      expect(flat_plugin).to.have.property('updatedAt');
-      expect(flat_plugin.updatedAt).to.equal(local_plugin.updatedAt);
     });
   });
 });

--- a/test/manager.1.build-in.spec.ts
+++ b/test/manager.1.build-in.spec.ts
@@ -81,10 +81,10 @@ describe('manage.js build-in plugins integration tests', function () {
         (plugins_local[first_plugin_uid] as StorageData)['status'],
         'release_plugins_local: ' + first_plugin_uid
       ).to.equal('on');
-      const all_plugins_1 = await manager!.getPlugins();
+      const { plugins: all_plugins_1 } = await manager!.getPluginsView();
       expect(
         all_plugins_1[second_plugin_uid]['status'],
-        'getPlugins(): ' + second_plugin_uid
+        'getPluginsView(): ' + second_plugin_uid
       ).to.not.equal('on');
     });
 

--- a/test/manager.2.external.spec.ts
+++ b/test/manager.2.external.spec.ts
@@ -119,14 +119,13 @@ describe('manage.js external plugins integration tests', function () {
       delete (run as PluginDict)[external_1_uid]['statusChangedAt'];
       expect(run).to.deep.equal(installed);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid
+        third_plugin_uid
       );
       expect(plugins_user, 'release_plugins_user').to.have.all.keys(external_1_uid);
 
@@ -136,13 +135,8 @@ describe('manage.js external plugins integration tests', function () {
       ).to.equal('on');
 
       expect(
-        (plugins_flat[external_1_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_1_uid
-      ).to.equal('on');
-
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_1_uid
+        (plugins_user[external_1_uid] as StorageData)['code'],
+        "release_plugins_user['code']: " + external_1_uid
       ).to.equal(external_code);
     });
 
@@ -181,15 +175,13 @@ describe('manage.js external plugins integration tests', function () {
       delete (run as PluginDict)[external_2_uid]['statusChangedAt'];
       expect(run).to.deep.equal(installed);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid,
-        external_2_uid
+        third_plugin_uid
       );
       expect(plugins_user, 'release_plugins_user').to.have.all.keys(external_1_uid, external_2_uid);
 
@@ -204,18 +196,8 @@ describe('manage.js external plugins integration tests', function () {
       ).to.equal('Misc');
 
       expect(
-        (plugins_flat[external_2_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_2_uid
-      ).to.equal('on');
-
-      expect(
-        (plugins_flat[external_2_uid] as StorageData)['category'],
-        "release_plugins_flat['category']: " + external_2_uid
-      ).to.equal('Misc');
-
-      expect(
-        (plugins_flat[external_2_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_2_uid
+        (plugins_user[external_2_uid] as StorageData)['code'],
+        "release_plugins_user['code']: " + external_2_uid
       ).to.equal(external_code);
     });
 
@@ -233,13 +215,11 @@ describe('manage.js external plugins integration tests', function () {
         'The plugin has an incorrect ==UserScript== header'
       );
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid,
-        external_2_uid
+        third_plugin_uid
       );
       expect(db_data['release_plugins_user'], 'release_plugins_user').to.have.all.keys(
         external_1_uid,
@@ -312,22 +292,15 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_2_uid, 'off');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid,
-        external_2_uid
+        third_plugin_uid
       );
       expect(plugins_user, 'release_plugins_user').to.have.all.keys(external_1_uid, external_2_uid);
-
-      expect(
-        (plugins_flat[external_2_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_2_uid
-      ).to.equal('off');
 
       expect(
         (plugins_user[external_2_uid] as StorageData)['status'],
@@ -346,22 +319,15 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_2_uid, 'on');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid,
-        external_2_uid
+        third_plugin_uid
       );
       expect(plugins_user, 'release_plugins_user').to.have.all.keys(external_1_uid, external_2_uid);
-
-      expect(
-        (plugins_flat[external_2_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_2_uid
-      ).to.equal('on');
 
       expect(
         (plugins_user[external_2_uid] as StorageData)['status'],
@@ -380,12 +346,11 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_2_uid, 'delete');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid
+        third_plugin_uid
       );
       expect(db_data['release_plugins_user'], 'release_plugins_user').to.have.all.keys(
         external_1_uid
@@ -403,8 +368,8 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_1_uid, 'delete');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -464,18 +429,17 @@ describe('manage.js external plugins integration tests', function () {
     });
 
     it('Check external plugin', async function () {
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
-        third_plugin_uid,
-        external_1_uid
+        third_plugin_uid
       );
-      expect((plugins_flat[external_1_uid] as StorageData)['override']).to.be.undefined;
       expect(db_data['release_plugins_user'], 'release_plugins_user').to.have.all.keys(
         external_1_uid
       );
+      const plugin_info = await manager!.getPluginInfo(external_1_uid);
+      expect(plugin_info!.override).to.be.undefined;
     });
 
     it('Remove the external plugin', async function () {
@@ -489,8 +453,8 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_1_uid, 'delete');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      expect(db_data['release_plugins_flat'], 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -541,10 +505,10 @@ describe('manage.js external plugins integration tests', function () {
       delete (run as PluginDict)[external_1_uid]['statusChangedAt'];
       expect(run).to.deep.equal(installed);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -556,15 +520,8 @@ describe('manage.js external plugins integration tests', function () {
         "release_plugins_user['code']: " + external_1_uid
       ).to.equal(external_code);
 
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_1_uid
-      ).to.equal(external_code);
-
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['override'],
-        "release_plugins_flat['override']: " + external_1_uid
-      ).to.be.true;
+      const plugin_view = await manager!.getPluginInfo(external_1_uid);
+      expect(plugin_view!.override, "getPluginInfo()['override']: " + external_1_uid).to.be.true;
     });
 
     it('Info about plugin', async function () {
@@ -588,20 +545,15 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_1_uid, 'off');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
       );
       expect(plugins_user, 'release_plugins_user').to.have.all.keys(external_1_uid);
-
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_1_uid
-      ).to.equal('off');
 
       expect(
         (plugins_user[external_1_uid] as StorageData)['status'],
@@ -617,29 +569,20 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_1_uid, 'delete');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
       );
       expect(db_data['release_plugins_user'], 'release_plugins_user').to.be.empty;
 
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_1_uid
-      ).to.equal('off');
-
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_1_uid
-      ).to.have.lengthOf(external_code.length);
-
-      expect(
-        (plugins_flat[external_1_uid] as StorageData)['override'],
-        "release_plugins_flat['override']: " + external_1_uid
-      ).to.not.be.true;
+      const plugin_after = await manager!.getPluginInfo(external_1_uid);
+      expect(plugin_after!.status, "getPluginInfo()['status']: " + external_1_uid).to.not.equal(
+        'on'
+      );
+      expect(plugin_after!.override, "getPluginInfo()['override']: " + external_1_uid).to.not.be
+        .true;
     });
   });
 
@@ -683,10 +626,10 @@ describe('manage.js external plugins integration tests', function () {
       delete (run as PluginDict)[external_3_uid]['statusChangedAt'];
       expect(run).to.deep.equal(installed);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      const plugins_catalog = db_data['release_plugins_catalog'] as StorageData;
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      expect(plugins_catalog, 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
@@ -697,14 +640,8 @@ describe('manage.js external plugins integration tests', function () {
         (plugins_user[external_3_uid] as StorageData)['code'],
         "release_plugins_user['code']: " + external_3_uid
       ).to.equal(external_code);
-      expect(
-        (plugins_flat[external_3_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_3_uid
-      ).to.equal(external_code);
-      expect(
-        (plugins_flat[external_3_uid] as StorageData)['override'],
-        "release_plugins_flat['override']: " + external_3_uid
-      ).to.be.true;
+      const plugin_view_3 = await manager!.getPluginInfo(external_3_uid);
+      expect(plugin_view_3!.override, "getPluginInfo()['override']: " + external_3_uid).to.be.true;
     });
 
     it('Remove external plugin and replace it with built-in plugin', async function () {
@@ -718,23 +655,20 @@ describe('manage.js external plugins integration tests', function () {
       const run = await manager!.managePlugin(external_3_uid, 'delete');
       expect(run).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
-      expect(plugins_flat, 'release_plugins_flat').to.have.all.keys(
+      const db_data = await storage.get(['release_plugins_catalog', 'release_plugins_user']);
+      expect(db_data['release_plugins_catalog'], 'release_plugins_catalog').to.have.all.keys(
         first_plugin_uid,
         second_plugin_uid,
         third_plugin_uid
       );
       expect(db_data['release_plugins_user'], 'release_plugins_user').to.be.empty;
 
-      expect(
-        (plugins_flat[external_3_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_3_uid
-      ).to.equal('off');
-      expect(
-        (plugins_flat[external_3_uid] as StorageData)['override'],
-        "release_plugins_flat['override']: " + external_3_uid
-      ).to.be.false;
+      const plugin_after_3 = await manager!.getPluginInfo(external_3_uid);
+      expect(plugin_after_3!.status, "getPluginInfo()['status']: " + external_3_uid).to.not.equal(
+        'on'
+      );
+      expect(plugin_after_3!.override, "getPluginInfo()['override']: " + external_3_uid).to.not.be
+        .true;
     });
 
     it('Enable and disable build-in plugin', async function () {
@@ -758,20 +692,19 @@ describe('manage.js external plugins integration tests', function () {
       const run2 = await manager!.managePlugin(external_3_uid, 'off');
       expect(run2).to.be.undefined;
 
-      const db_data = await storage.get(['release_plugins_flat']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_local']);
+      const plugins_local = db_data['release_plugins_local'] as StorageData;
       expect(
-        (plugins_flat[external_3_uid] as StorageData)['status'],
-        "release_plugins_flat['status']: " + external_3_uid
+        (plugins_local[external_3_uid] as StorageData)['status'],
+        "release_plugins_local['status']: " + external_3_uid
       ).to.equal('off');
       expect(
-        (plugins_flat[external_3_uid] as StorageData)['code'],
-        "release_plugins_flat['code']: " + external_3_uid
+        (plugins_local[external_3_uid] as StorageData)['code'],
+        "release_plugins_local['code']: " + external_3_uid
       ).to.not.equal(external_code);
-      expect(
-        (plugins_flat[external_3_uid] as StorageData)['override'],
-        "release_plugins_flat['override']: " + external_3_uid
-      ).to.be.false;
+      const plugin_view_after = await manager!.getPluginInfo(external_3_uid);
+      expect(plugin_view_after!.override, "getPluginInfo()['override']: " + external_3_uid).to.not
+        .be.true;
     });
   });
 
@@ -908,11 +841,9 @@ describe('manage.js external plugins integration tests', function () {
       await manager!.addUserScripts([plugin_data]);
 
       // Get stored data
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const db_data = await storage.get(['release_plugins_user']);
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
       const user_plugin = plugins_user[external_plugin_uid] as StorageData;
-      const flat_plugin = plugins_flat[external_plugin_uid] as StorageData;
 
       // Check timestamps in plugins_user
       expect(user_plugin).to.have.property('addedAt');
@@ -921,13 +852,6 @@ describe('manage.js external plugins integration tests', function () {
 
       expect(user_plugin).to.have.property('statusChangedAt');
       expect(user_plugin.statusChangedAt).to.equal(user_plugin.addedAt);
-
-      // Check timestamps in plugins_flat
-      expect(flat_plugin).to.have.property('addedAt');
-      expect(flat_plugin.addedAt).to.equal(user_plugin.addedAt);
-
-      expect(flat_plugin).to.have.property('statusChangedAt');
-      expect(flat_plugin.statusChangedAt).to.equal(user_plugin.statusChangedAt);
     });
 
     it('should update statusChangedAt when toggling plugin status', async function () {
@@ -942,15 +866,12 @@ describe('manage.js external plugins integration tests', function () {
       // Toggle plugin off
       await manager!.managePlugin(external_plugin_uid, 'off');
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const db_data = await storage.get(['release_plugins_user']);
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
       const user_plugin = plugins_user[external_plugin_uid] as StorageData;
-      const flat_plugin = plugins_flat[external_plugin_uid] as StorageData;
 
       // Check new statusChangedAt
       expect(user_plugin.statusChangedAt as number).to.be.above(oldStatusChangedAt);
-      expect(flat_plugin.statusChangedAt).to.equal(user_plugin.statusChangedAt);
 
       // Original addedAt should remain unchanged
       expect(user_plugin.addedAt).to.equal(
@@ -961,7 +882,7 @@ describe('manage.js external plugins integration tests', function () {
 
     it('should handle timestamps correctly when removing plugin', async function () {
       // Get initial data
-      const before = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const before = await storage.get(['release_plugins_user']);
       const before_user = (before['release_plugins_user'] as StorageData)[
         external_plugin_uid
       ] as StorageData;
@@ -972,13 +893,10 @@ describe('manage.js external plugins integration tests', function () {
       await manager!.managePlugin(external_plugin_uid, 'delete');
 
       // Check data after removal
-      const after = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const after = await storage.get(['release_plugins_user']);
 
       // Plugin should be removed from plugins_user
       expect(after['release_plugins_user']).to.not.have.property(external_plugin_uid);
-
-      // Plugin should be removed from plugins_flat
-      expect(after['release_plugins_flat']).to.not.have.property(external_plugin_uid);
     });
   });
 
@@ -1026,20 +944,14 @@ describe('manage.js external plugins integration tests', function () {
       // Add overriding plugin
       await manager!.addUserScripts([override_plugin]);
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const db_data = await storage.get(['release_plugins_user']);
       const plugins_user = db_data['release_plugins_user'] as StorageData;
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
       const user_plugin = plugins_user[built_in_plugin_uid] as StorageData;
-      const flat_plugin = plugins_flat[built_in_plugin_uid] as StorageData;
 
       // Check timestamps in plugins_user
       expect(user_plugin).to.have.property('addedAt');
       expect(user_plugin).to.have.property('statusChangedAt');
       expect(user_plugin.statusChangedAt).to.equal(user_plugin.addedAt);
-
-      // Check timestamps copied to plugins_flat
-      expect(flat_plugin.addedAt).to.equal(user_plugin.addedAt);
-      expect(flat_plugin.statusChangedAt).to.equal(user_plugin.statusChangedAt);
     });
 
     it('should update statusChangedAt when toggling overridden plugin', async function () {
@@ -1056,34 +968,29 @@ describe('manage.js external plugins integration tests', function () {
       // Toggle plugin off
       await manager!.managePlugin(built_in_plugin_uid, 'off');
 
-      const after = await storage.get(['release_plugins_flat', 'release_plugins_user']);
+      const after = await storage.get(['release_plugins_user']);
       const after_user = (after['release_plugins_user'] as StorageData)[
-        built_in_plugin_uid
-      ] as StorageData;
-      const after_flat = (after['release_plugins_flat'] as StorageData)[
         built_in_plugin_uid
       ] as StorageData;
 
       // Check statusChangedAt updated
       expect(after_user.statusChangedAt as number).to.be.above(oldStatusChangedAt);
-      expect(after_flat.statusChangedAt).to.equal(after_user.statusChangedAt);
 
       // Check addedAt preserved
       expect(after_user.addedAt).to.equal(addedAt);
-      expect(after_flat.addedAt).to.equal(addedAt);
     });
 
     it('should handle timestamps correctly when removing override', async function () {
       // Remove override
       await manager!.managePlugin(built_in_plugin_uid, 'delete');
 
-      const db_data = await storage.get(['release_plugins_flat', 'release_plugins_user']);
-      const plugins_flat = db_data['release_plugins_flat'] as StorageData;
+      const db_data = await storage.get(['release_plugins_user']);
 
       // Override should be removed from plugins_user
       expect(db_data['release_plugins_user']).to.not.have.property(built_in_plugin_uid);
-      // Built-in plugin should be restored in plugins_flat without override timestamps
-      expect(plugins_flat[built_in_plugin_uid] as StorageData).to.not.have.property('addedAt');
+      // Built-in plugin restored in catalog view should not have addedAt
+      const plugin_view = await manager!.getPluginInfo(built_in_plugin_uid);
+      expect(plugin_view!).to.not.have.property('addedAt');
     });
   });
 });

--- a/test/manager.2.external.spec.ts
+++ b/test/manager.2.external.spec.ts
@@ -228,17 +228,8 @@ describe('manage.js external plugins integration tests', function () {
     });
 
     it('Check categories before switching channel', async function () {
-      const categories = await storage
-        .get(['release_categories'])
-        .then(data => data['release_categories']);
-      expect(categories).to.have.all.keys(
-        'Info',
-        'Map Tiles',
-        'Obsolete',
-        'Deleted',
-        'Controls',
-        'Misc'
-      );
+      const { categories } = await manager!.getPluginsView();
+      expect(categories).to.include.all.keys('Info', 'Map Tiles', 'Controls', 'Misc');
     });
 
     it('Switching to the Beta channel and back to Release', async function () {
@@ -268,17 +259,8 @@ describe('manage.js external plugins integration tests', function () {
     });
 
     it('Check categories after switching channel', async function () {
-      const categories = await storage
-        .get(['release_categories'])
-        .then(data => data['release_categories']);
-      expect(categories).to.have.all.keys(
-        'Info',
-        'Map Tiles',
-        'Obsolete',
-        'Deleted',
-        'Controls',
-        'Misc'
-      );
+      const { categories } = await manager!.getPluginsView();
+      expect(categories).to.include.all.keys('Info', 'Map Tiles', 'Controls', 'Misc');
     });
 
     it('Disable external plugin', async function () {

--- a/test/manager.5.plugins-changed.spec.ts
+++ b/test/manager.5.plugins-changed.spec.ts
@@ -4,30 +4,30 @@ import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';
 import storage from '../test/storage.js';
 import { expect } from 'chai';
-import type { ManagerConfig, PluginDict } from '../src/types.js';
+import type { ManagerConfig, PluginsView } from '../src/types.js';
 
 /**
- * Returns a Promise that resolves with the next plugins_changed invocation payload.
+ * Returns a Promise that resolves with the next plugins_view_changed invocation payload.
  * Replaces the callback with a one-shot wrapper, then restores the original.
  */
-function nextPluginsChanged(manager: Manager): Promise<PluginDict> {
-  return new Promise<PluginDict>(resolve => {
-    const prev = manager.plugins_changed;
-    manager.plugins_changed = (plugins: PluginDict) => {
-      manager.plugins_changed = prev;
-      if (prev) prev(plugins);
-      resolve(plugins);
+function nextPluginsViewChanged(manager: Manager): Promise<PluginsView> {
+  return new Promise<PluginsView>(resolve => {
+    const prev = manager.plugins_view_changed;
+    manager.plugins_view_changed = (view: PluginsView) => {
+      manager.plugins_view_changed = prev;
+      if (prev) prev(view);
+      resolve(view);
     };
   });
 }
 
-describe('plugins_changed callback', function () {
+describe('plugins_view_changed callback', function () {
   const first_plugin_uid =
     'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion';
   const second_plugin_uid = 'Bing maps+https://github.com/IITC-CE/ingress-intel-total-conversion';
   const third_plugin_uid = 'Missions+https://github.com/IITC-CE/ingress-intel-total-conversion';
 
-  const base_config: Omit<ManagerConfig, 'plugins_changed'> = {
+  const base_config: Omit<ManagerConfig, 'plugins_view_changed'> = {
     storage,
     channel: 'release',
     network_host: {
@@ -46,33 +46,33 @@ describe('plugins_changed callback', function () {
 
     before(async function () {
       storage.resetStorage();
-      manager = new Manager({ ...base_config, plugins_changed: () => {} });
+      manager = new Manager({ ...base_config, plugins_view_changed: () => {} });
     });
 
     it('fires on run() and delivers all catalog plugins', async function () {
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.run();
-      const plugins = await next;
+      const { plugins } = await next;
       expect(plugins).to.include.all.keys(first_plugin_uid, second_plugin_uid, third_plugin_uid);
     });
 
     it('fires on managePlugin on with updated status', async function () {
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.managePlugin(first_plugin_uid, 'on');
-      const plugins = await next;
+      const { plugins } = await next;
       expect(plugins[first_plugin_uid].status).to.equal('on');
     });
 
     it('fires on managePlugin off with updated status', async function () {
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.managePlugin(first_plugin_uid, 'off');
-      const plugins = await next;
+      const { plugins } = await next;
       expect(plugins[first_plugin_uid].status).to.equal('off');
     });
 
     it('fires on addUserScripts and new plugin is present', async function () {
       const ext_uid = 'Test External+https://github.com/IITC-CE/ingress-intel-total-conversion';
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.addUserScripts([
         {
           meta: {
@@ -84,7 +84,7 @@ describe('plugins_changed callback', function () {
           code: '// ==UserScript==\nreturn false;',
         },
       ]);
-      const plugins = await next;
+      const { plugins } = await next;
       expect(plugins).to.have.property(ext_uid);
       expect(plugins[ext_uid].user).to.be.true;
       expect(plugins[ext_uid].status).to.equal('on');
@@ -92,26 +92,26 @@ describe('plugins_changed callback', function () {
 
     it('fires on managePlugin delete and plugin is absent', async function () {
       const ext_uid = 'Test External+https://github.com/IITC-CE/ingress-intel-total-conversion';
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.managePlugin(ext_uid, 'delete');
-      const plugins = await next;
+      const { plugins } = await next;
       expect(plugins).to.not.have.property(ext_uid);
     });
 
     it('fires on setChannel and reflects channel switch', async function () {
-      const next = nextPluginsChanged(manager);
+      const next = nextPluginsViewChanged(manager);
       await manager.setChannel('beta');
       await next;
       expect(manager.channel).to.equal('beta');
 
-      const next2 = nextPluginsChanged(manager);
+      const next2 = nextPluginsViewChanged(manager);
       await manager.setChannel('release');
       await next2;
       expect(manager.channel).to.equal('release');
     });
   });
 
-  describe('merged view correctness via getPlugins()', function () {
+  describe('merged view correctness via getPluginsView()', function () {
     let manager: Manager;
 
     before(async function () {
@@ -121,14 +121,14 @@ describe('plugins_changed callback', function () {
     });
 
     it('catalog-only plugin has status off (not yet installed)', async function () {
-      const plugins = await manager.getPlugins();
+      const { plugins } = await manager.getPluginsView();
       expect(plugins).to.have.property(second_plugin_uid);
       expect(plugins[second_plugin_uid].status).to.equal('off');
     });
 
     it('enabled built-in shows status on without user or override flags', async function () {
       await manager.managePlugin(first_plugin_uid, 'on');
-      const plugins = await manager.getPlugins();
+      const { plugins } = await manager.getPluginsView();
       expect(plugins[first_plugin_uid].status).to.equal('on');
       expect(plugins[first_plugin_uid].user).to.not.be.true;
       expect(plugins[first_plugin_uid].override).to.not.be.true;
@@ -144,7 +144,7 @@ describe('plugins_changed callback', function () {
           code: '// ==UserScript==\nreturn false;',
         },
       ]);
-      const plugins = await manager.getPlugins();
+      const { plugins } = await manager.getPluginsView();
       expect(plugins[third_plugin_uid].override).to.be.true;
       expect(plugins[third_plugin_uid].user).to.be.true;
       expect(plugins[third_plugin_uid].status).to.equal('on');
@@ -152,7 +152,7 @@ describe('plugins_changed callback', function () {
 
     it('after override removal plugin has no override or user flags', async function () {
       await manager.managePlugin(third_plugin_uid, 'delete');
-      const plugins = await manager.getPlugins();
+      const { plugins } = await manager.getPluginsView();
       expect(plugins[third_plugin_uid].override).to.not.be.true;
       expect(plugins[third_plugin_uid].user).to.not.be.true;
     });
@@ -164,8 +164,46 @@ describe('plugins_changed callback', function () {
           [beta_uid]: { uid: beta_uid, status: 'on', code: '// beta-only' },
         },
       });
-      const plugins = await manager.getPlugins();
+      const { plugins } = await manager.getPluginsView();
       expect(plugins).to.not.have.property(beta_uid);
+    });
+
+    it('categories contains all plugin categories sorted alphabetically', async function () {
+      const { categories } = await manager.getPluginsView();
+      const names = Object.keys(categories);
+      expect(names.length).to.be.greaterThan(0);
+      expect(names).to.deep.equal([...names].sort((a, b) => a.localeCompare(b)));
+      for (const cat of Object.values(categories)) {
+        expect(cat).to.have.property('name').that.is.a('string');
+        expect(cat).to.have.property('isNew').that.is.a('boolean');
+      }
+    });
+
+    it('isNew is true for a category with a recently added user plugin', async function () {
+      const recentManager = new Manager({ ...base_config, new_plugin_threshold: 3600 });
+      await recentManager.run();
+      await recentManager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://example.com',
+            name: 'Brand New Plugin',
+            category: 'Misc',
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const { categories } = await recentManager.getPluginsView();
+      expect(categories['Misc'].isNew).to.be.true;
+    });
+
+    it('isNew is false for catalog-only categories (no addedAt)', async function () {
+      storage.resetStorage();
+      const freshManager = new Manager(base_config);
+      await freshManager.run();
+      const { categories } = await freshManager.getPluginsView();
+      for (const cat of Object.values(categories)) {
+        expect(cat.isNew, `category ${cat.name} should not be new`).to.be.false;
+      }
     });
   });
 });

--- a/test/manager.5.plugins-changed.spec.ts
+++ b/test/manager.5.plugins-changed.spec.ts
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
+
+import { describe, it, before } from 'mocha';
+import { Manager } from '../src/manager.js';
+import storage from '../test/storage.js';
+import { expect } from 'chai';
+import type { ManagerConfig, PluginDict } from '../src/types.js';
+
+/**
+ * Returns a Promise that resolves with the next plugins_changed invocation payload.
+ * Replaces the callback with a one-shot wrapper, then restores the original.
+ */
+function nextPluginsChanged(manager: Manager): Promise<PluginDict> {
+  return new Promise<PluginDict>(resolve => {
+    const prev = manager.plugins_changed;
+    manager.plugins_changed = (plugins: PluginDict) => {
+      manager.plugins_changed = prev;
+      if (prev) prev(plugins);
+      resolve(plugins);
+    };
+  });
+}
+
+describe('plugins_changed callback', function () {
+  const first_plugin_uid =
+    'Available AP statistics+https://github.com/IITC-CE/ingress-intel-total-conversion';
+  const second_plugin_uid = 'Bing maps+https://github.com/IITC-CE/ingress-intel-total-conversion';
+  const third_plugin_uid = 'Missions+https://github.com/IITC-CE/ingress-intel-total-conversion';
+
+  const base_config: Omit<ManagerConfig, 'plugins_changed'> = {
+    storage,
+    channel: 'release',
+    network_host: {
+      release: 'http://127.0.0.1:31606/release',
+      beta: 'http://127.0.0.1:31606/beta',
+      custom: 'http://127.0.0.1/',
+    },
+    inject_user_script: () => {},
+    inject_plugin: () => {},
+    progressbar: () => {},
+    is_daemon: false,
+  };
+
+  describe('fires on each mutating operation', function () {
+    let manager: Manager;
+
+    before(async function () {
+      storage.resetStorage();
+      manager = new Manager({ ...base_config, plugins_changed: () => {} });
+    });
+
+    it('fires on run() and delivers all catalog plugins', async function () {
+      const next = nextPluginsChanged(manager);
+      await manager.run();
+      const plugins = await next;
+      expect(plugins).to.include.all.keys(first_plugin_uid, second_plugin_uid, third_plugin_uid);
+    });
+
+    it('fires on managePlugin on with updated status', async function () {
+      const next = nextPluginsChanged(manager);
+      await manager.managePlugin(first_plugin_uid, 'on');
+      const plugins = await next;
+      expect(plugins[first_plugin_uid].status).to.equal('on');
+    });
+
+    it('fires on managePlugin off with updated status', async function () {
+      const next = nextPluginsChanged(manager);
+      await manager.managePlugin(first_plugin_uid, 'off');
+      const plugins = await next;
+      expect(plugins[first_plugin_uid].status).to.equal('off');
+    });
+
+    it('fires on addUserScripts and new plugin is present', async function () {
+      const ext_uid = 'Test External+https://github.com/IITC-CE/ingress-intel-total-conversion';
+      const next = nextPluginsChanged(manager);
+      await manager.addUserScripts([
+        {
+          meta: {
+            id: 'test-ext',
+            namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+            name: 'Test External',
+            category: 'Misc',
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const plugins = await next;
+      expect(plugins).to.have.property(ext_uid);
+      expect(plugins[ext_uid].user).to.be.true;
+      expect(plugins[ext_uid].status).to.equal('on');
+    });
+
+    it('fires on managePlugin delete and plugin is absent', async function () {
+      const ext_uid = 'Test External+https://github.com/IITC-CE/ingress-intel-total-conversion';
+      const next = nextPluginsChanged(manager);
+      await manager.managePlugin(ext_uid, 'delete');
+      const plugins = await next;
+      expect(plugins).to.not.have.property(ext_uid);
+    });
+
+    it('fires on setChannel and reflects channel switch', async function () {
+      const next = nextPluginsChanged(manager);
+      await manager.setChannel('beta');
+      await next;
+      expect(manager.channel).to.equal('beta');
+
+      const next2 = nextPluginsChanged(manager);
+      await manager.setChannel('release');
+      await next2;
+      expect(manager.channel).to.equal('release');
+    });
+  });
+
+  describe('merged view correctness via getPlugins()', function () {
+    let manager: Manager;
+
+    before(async function () {
+      storage.resetStorage();
+      manager = new Manager(base_config);
+      await manager.run();
+    });
+
+    it('catalog-only plugin has status off (not yet installed)', async function () {
+      const plugins = await manager.getPlugins();
+      expect(plugins).to.have.property(second_plugin_uid);
+      expect(plugins[second_plugin_uid].status).to.equal('off');
+    });
+
+    it('enabled built-in shows status on without user or override flags', async function () {
+      await manager.managePlugin(first_plugin_uid, 'on');
+      const plugins = await manager.getPlugins();
+      expect(plugins[first_plugin_uid].status).to.equal('on');
+      expect(plugins[first_plugin_uid].user).to.not.be.true;
+      expect(plugins[first_plugin_uid].override).to.not.be.true;
+    });
+
+    it('user plugin replacing a built-in gets override and user flags in merged view', async function () {
+      await manager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+            name: 'Missions',
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const plugins = await manager.getPlugins();
+      expect(plugins[third_plugin_uid].override).to.be.true;
+      expect(plugins[third_plugin_uid].user).to.be.true;
+      expect(plugins[third_plugin_uid].status).to.equal('on');
+    });
+
+    it('after override removal plugin has no override or user flags', async function () {
+      await manager.managePlugin(third_plugin_uid, 'delete');
+      const plugins = await manager.getPlugins();
+      expect(plugins[third_plugin_uid].override).to.not.be.true;
+      expect(plugins[third_plugin_uid].user).to.not.be.true;
+    });
+
+    it('plugins stored under another channel are excluded from the current view', async function () {
+      const beta_uid = 'Beta Only Plugin+https://example.com';
+      await storage.set({
+        beta_plugins_local: {
+          [beta_uid]: { uid: beta_uid, status: 'on', code: '// beta-only' },
+        },
+      });
+      const plugins = await manager.getPlugins();
+      expect(plugins).to.not.have.property(beta_uid);
+    });
+  });
+});

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -76,5 +76,26 @@ describe('test migrations', function () {
       const db_data = await storage.get(['release_update_check_interval']);
       expect(db_data['release_update_check_interval']).to.be.equal(6 * 60 * 60);
     });
+    it('Should populate plugins_catalog from plugins_flat without runtime fields', async function () {
+      const db_data = await storage.get(['release_plugins_catalog']);
+      const catalog = db_data['release_plugins_catalog'] as StorageData;
+      expect(catalog).to.be.an('object');
+
+      const bookmarkUid =
+        'Bookmarks for maps and portals+https://github.com/IITC-CE/ingress-intel-total-conversion';
+      const plugin = catalog[bookmarkUid] as StorageData;
+      expect(plugin).to.be.an('object');
+      expect(plugin['id']).to.equal('bookmarks');
+      expect(plugin['category']).to.equal('Controls');
+
+      // Runtime fields must not be present in catalog
+      expect(plugin).to.not.have.property('code');
+      expect(plugin).to.not.have.property('status');
+      expect(plugin).to.not.have.property('user');
+      expect(plugin).to.not.have.property('override');
+      expect(plugin).to.not.have.property('addedAt');
+      expect(plugin).to.not.have.property('statusChangedAt');
+      expect(plugin).to.not.have.property('updatedAt');
+    });
   });
 });

--- a/test/migrations.spec.ts
+++ b/test/migrations.spec.ts
@@ -45,8 +45,8 @@ describe('test migrations', function () {
 
   describe('check migrations', function () {
     it('Should replace undefined with "Misc" (fix https://github.com/IITC-CE/IITC-Button/issues/68)', async function () {
-      const db_data = await storage.get(['release_plugins_flat']);
-      const ext_plugin = (db_data['release_plugins_flat'] as StorageData)[
+      const db_data = await storage.get(['release_plugins_catalog']);
+      const ext_plugin = (db_data['release_plugins_catalog'] as StorageData)[
         'External+https://github.com/IITC-CE/ingress-intel-total-conversion'
       ] as StorageData;
       expect(ext_plugin['category']).to.equal('Misc');


### PR DESCRIPTION
- Removes `${channel}_plugins_flat` from storage. This key was a pre-computed merged view of all plugins (catalog + local + user), written on every update. It is no longer stored.
- Removes `${channel}_categories` from storage. Categories are now derived on demand from the current plugin set.
- Introduces `${channel}_plugins_catalog` - server-side metadata only (name, description, filename, namespace, etc.), no runtime state (status, code, user flags).
- Adds `getPluginsView(): Promise<PluginsView>` - returns the merged view of plugins and categories on demand.
- Adds `plugins_view_changed` config callback - fires with `PluginsView` whenever the plugin set changes (after `run()`, `managePlugin()`, `addUserScripts()`, `setChannel()`).
- Categories in `PluginsView` are computed from the merged plugin set: non-empty only, sorted alphabetically, each carrying an `isNew` flag (true if any plugin in the category has `addedAt` within `new_plugin_threshold` seconds, default 3600).
- Plugin `status` in the merged view is always `'on'` or `'off'` - never `undefined`.
- Migration 0006 runs automatically on `manager.run()`: populates `plugins_catalog` from existing `plugins_flat` data (strips runtime fields), then nullifies both the flat key and the categories key.

