### PR TITLE
feat: expose IITC core in PluginsView

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,24 @@ const manager = new Manager({
         console.log("Injecting plugin:", plugin.name);
         console.log(plugin.code);
     },
-    plugins_view_changed: ({ plugins, categories }) => {
-        // Called whenever the plugin set changes.
+    plugins_view_changed: ({ plugins, categories, core }) => {
+        // Called whenever the plugin set or IITC core changes.
         // plugins - merged view of all plugins (catalog + state + user overrides).
         // categories - non-empty categories derived from plugins, sorted alphabetically.
+        // core - current IITC core Plugin object, or null if not yet downloaded.
         console.log("Plugin list updated:", Object.keys(plugins).length, "plugins");
         console.log("Categories:", Object.keys(categories));
+        console.log("IITC core version:", core?.version ?? "not downloaded");
     },
 });
 
 manager.run().then();
 ```
 
-### Getting the current plugin list and categories
+### Getting the current plugin list, categories and core
 
 ```js
-const { plugins, categories } = await manager.getPluginsView();
+const { plugins, categories, core } = await manager.getPluginsView();
 
 // plugins is a PluginDict - keyed by uid, each entry is a merged Plugin object.
 // Fields: uid, name, category, status ('on'/'off'), user, override, code, ...
@@ -56,6 +58,12 @@ for (const [uid, plugin] of Object.entries(plugins)) {
 // isNew is true if any plugin in that category was added within new_plugin_threshold seconds.
 for (const [name, cat] of Object.entries(categories)) {
     console.log(name, cat.isNew ? '(new)' : '');
+}
+
+// core is the active IITC core Plugin object, or null if not yet downloaded.
+// core.override is true when the user has installed a custom IITC core script.
+if (core) {
+    console.log("IITC core version:", core.version, core.override ? "(user override)" : "");
 }
 ```
 
@@ -110,6 +118,10 @@ The library uses two kinds of storage keys.
 ### `${channel}_plugins_state` and `${channel}_plugins_user` merged into global keys
 
 Per-channel state keys (`release_plugins_state`, `beta_plugins_state`, …) and per-channel user-plugin keys (`release_plugins_user`, …) have been replaced by a single `plugins_state` and `plugins_user` shared across all channels. The migration runs automatically on the first `run()` call.
+
+### `getIITCCore()` removed
+
+`getIITCCore()` is no longer part of the public API. Use `getPluginsView()` instead - it now returns a `core: Plugin | null` field alongside `plugins` and `categories`.
 
 ### `${channel}_iitc_core_user` merged into global `iitc_core_user`
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -113,6 +113,8 @@ export class Manager extends Worker {
     const storage = await this.storage.get([
       `${channel}_plugins_catalog`,
       `${channel}_plugins_local`,
+      `${channel}_iitc_core`,
+      'iitc_core_user',
       'plugins_user',
       'plugins_state',
     ]);
@@ -121,8 +123,17 @@ export class Manager extends Worker {
     const plugins_local = (storage[`${channel}_plugins_local`] || {}) as PluginDict;
     const plugins_user = (storage['plugins_user'] || {}) as PluginDict;
     const plugins_state = (storage['plugins_state'] || {}) as PluginStateDict;
+    const iitc_core = storage[`${channel}_iitc_core`] as Plugin | undefined;
+    const iitc_core_user = storage['iitc_core_user'] as Plugin | undefined;
 
-    return this._computePluginsView(plugins_catalog, plugins_local, plugins_user, plugins_state);
+    return this._computePluginsView(
+      plugins_catalog,
+      plugins_local,
+      plugins_user,
+      plugins_state,
+      iitc_core,
+      iitc_core_user
+    );
   }
 
   _emitPluginsChanged(): void {
@@ -148,12 +159,16 @@ export class Manager extends Worker {
     const plugins_local = (storage[`${channel}_plugins_local`] || {}) as PluginDict;
     const plugins_user = (storage['plugins_user'] || {}) as PluginDict;
     const plugins_state = (storage['plugins_state'] || {}) as PluginStateDict;
+    const iitc_core = storage[`${channel}_iitc_core`] as Plugin | undefined;
+    const iitc_core_user = storage['iitc_core_user'] as Plugin | undefined;
 
-    const { plugins: all_plugins } = this._computePluginsView(
+    const { plugins: all_plugins, core: iitc_script } = this._computePluginsView(
       plugins_catalog,
       plugins_local,
       plugins_user,
-      plugins_state
+      plugins_state,
+      iitc_core,
+      iitc_core_user
     );
 
     const enabled_plugins: PluginDict = {};
@@ -172,8 +187,6 @@ export class Manager extends Worker {
         match: ['https://*/*'],
       };
     }
-
-    const iitc_script = await this.getIITCCore(storage);
     if (iitc_script !== null) {
       if (iitc_script.code) {
         iitc_script.code = appendSourceUrl({
@@ -416,32 +429,6 @@ export class Manager extends Worker {
   async getPluginInfo(uid: string): Promise<Plugin | null> {
     const { plugins } = await this.getPluginsView();
     return plugins[uid] ?? null;
-  }
-
-  /**
-   * Returns IITC core script.
-   *
-   * @param storage - Storage object with keys `channel_iitc_core` and `iitc_core_user`.
-   * @param channel - Current channel.
-   */
-  async getIITCCore(storage?: StorageData, channel?: string): Promise<Plugin | null> {
-    if (typeof channel === 'undefined') channel = this.channel;
-
-    if (storage === undefined || !isSet(storage[`${channel}_iitc_core`])) {
-      storage = await this.storage.get([`${channel}_iitc_core`, 'iitc_core_user']);
-    }
-
-    const iitc_core = storage[`${channel}_iitc_core`] as Plugin | undefined;
-    const iitc_core_user = storage['iitc_core_user'] as Plugin | undefined;
-
-    let iitc_script: Plugin | null = null;
-    if (isSet(iitc_core_user) && isSet(iitc_core_user!['code'])) {
-      iitc_script = iitc_core_user!;
-      iitc_script['override'] = true;
-    } else if (isSet(iitc_core) && isSet(iitc_core!['code'])) {
-      iitc_script = iitc_core!;
-    }
-    return iitc_script;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,8 @@ export interface PluginsView {
   plugins: PluginDict;
   /** Non-empty categories derived from the current plugin set, sorted alphabetically. */
   categories: CategoryViewDict;
+  /** Current IITC core script, or null if not yet downloaded. */
+  core: Plugin | null;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -527,6 +527,89 @@ export class Worker {
     return { plugins_local, added_uids, updated_uids, removed_uids };
   }
 
+  /** @internal */
+  _computePlugins(
+    raw_plugins: PluginDict,
+    plugins_local: PluginDict,
+    plugins_user: PluginDict,
+    plugins_state: PluginStateDict
+  ): PluginDict {
+    if (!isSet(plugins_local)) plugins_local = {};
+    if (!isSet(plugins_user)) plugins_user = {};
+
+    const data: PluginDict = {};
+    for (const [uid, plugin] of Object.entries(raw_plugins)) {
+      data[uid] = { ...plugin, status: 'off' };
+    }
+
+    // Build a set of catalog UIDs to skip stale local entries removed from the server catalog
+    const currentChannelPluginUIDs = new Set(Object.keys(data));
+
+    Object.keys(plugins_local).forEach(plugin_uid => {
+      if (currentChannelPluginUIDs.has(plugin_uid)) {
+        const localPlugin = plugins_local[plugin_uid];
+        const state = plugins_state[plugin_uid];
+        data[plugin_uid].status = state?.status ?? 'off';
+        data[plugin_uid].statusChangedAt = state?.statusChangedAt;
+        data[plugin_uid].code = localPlugin.code;
+        data[plugin_uid].updatedAt = localPlugin.updatedAt;
+      }
+    });
+
+    Object.keys(plugins_user).forEach(plugin_uid => {
+      const userPlugin = plugins_user[plugin_uid];
+      const state = plugins_state[plugin_uid];
+      const pluginStatus = state?.status ?? 'off';
+      if (plugin_uid in data) {
+        data[plugin_uid].status = pluginStatus;
+        data[plugin_uid].statusChangedAt = state?.statusChangedAt;
+        data[plugin_uid].code = userPlugin.code;
+        data[plugin_uid].user = true;
+        data[plugin_uid].override = true;
+        data[plugin_uid].addedAt = userPlugin.addedAt;
+        data[plugin_uid].updatedAt = userPlugin.updatedAt;
+      } else {
+        data[plugin_uid] = {
+          ...userPlugin,
+          status: pluginStatus,
+          statusChangedAt: state?.statusChangedAt,
+        };
+      }
+      data[plugin_uid].user = true;
+    });
+
+    return data;
+  }
+
+  /** @internal */
+  _computeCategories(plugins: PluginDict): CategoryViewDict {
+    const now = Math.floor(Date.now() / 1000);
+    const threshold = this.new_plugin_threshold;
+    const rawCategories: CategoryViewDict = {};
+    for (const plugin of Object.values(plugins)) {
+      const cat = plugin.category || 'Misc';
+      if (!(cat in rawCategories)) {
+        rawCategories[cat] = { name: cat, isNew: false };
+      }
+      if (plugin.addedAt && now - plugin.addedAt <= threshold) {
+        rawCategories[cat].isNew = true;
+      }
+    }
+    return Object.fromEntries(Object.entries(rawCategories).sort(([a], [b]) => a.localeCompare(b)));
+  }
+
+  /** @internal */
+  _computeCore(iitc_core: Plugin | undefined, iitc_core_user: Plugin | undefined): Plugin | null {
+    if (isSet(iitc_core_user) && isSet(iitc_core_user!['code'])) {
+      iitc_core_user!['override'] = true;
+      return iitc_core_user!;
+    }
+    if (isSet(iitc_core) && isSet(iitc_core!['code'])) {
+      return iitc_core!;
+    }
+    return null;
+  }
+
   /**
    * Computes a merged view of all plugins, categories and IITC core.
    *
@@ -545,79 +628,10 @@ export class Worker {
     iitc_core?: Plugin,
     iitc_core_user?: Plugin
   ): PluginsView {
-    if (!isSet(plugins_local)) plugins_local = {};
-    if (!isSet(plugins_user)) plugins_user = {};
-
-    const data: PluginDict = {};
-    for (const [uid, plugin] of Object.entries(raw_plugins)) {
-      data[uid] = { ...plugin, status: 'off' };
-    }
-
-    // Build a set of catalog UIDs to skip stale local entries removed from the server catalog
-    const currentChannelPluginUIDs = new Set(Object.keys(data));
-
-    // Apply local code for installed built-in plugins
-    Object.keys(plugins_local).forEach(plugin_uid => {
-      if (currentChannelPluginUIDs.has(plugin_uid)) {
-        const localPlugin = plugins_local[plugin_uid];
-        const state = plugins_state[plugin_uid];
-        data[plugin_uid].status = state?.status ?? 'off';
-        data[plugin_uid].statusChangedAt = state?.statusChangedAt;
-        data[plugin_uid].code = localPlugin.code;
-        data[plugin_uid].updatedAt = localPlugin.updatedAt;
-      }
-    });
-
-    // Apply user plugins
-    if (Object.keys(plugins_user).length) {
-      Object.keys(plugins_user).forEach(plugin_uid => {
-        const userPlugin = plugins_user[plugin_uid];
-        const state = plugins_state[plugin_uid];
-        const pluginStatus = state?.status ?? 'off';
-        if (plugin_uid in data) {
-          data[plugin_uid].status = pluginStatus;
-          data[plugin_uid].statusChangedAt = state?.statusChangedAt;
-          data[plugin_uid].code = userPlugin.code;
-          data[plugin_uid].user = true;
-          data[plugin_uid].override = true;
-          data[plugin_uid].addedAt = userPlugin.addedAt;
-          data[plugin_uid].updatedAt = userPlugin.updatedAt;
-        } else {
-          data[plugin_uid] = {
-            ...userPlugin,
-            status: pluginStatus,
-            statusChangedAt: state?.statusChangedAt,
-          };
-        }
-        data[plugin_uid].user = true;
-      });
-    }
-
-    // Derive categories from merged plugins: filter empty, mark isNew, sort alphabetically
-    const now = Math.floor(Date.now() / 1000);
-    const threshold = this.new_plugin_threshold;
-    const rawCategories: CategoryViewDict = {};
-    for (const plugin of Object.values(data)) {
-      const cat = plugin.category || 'Misc';
-      if (!(cat in rawCategories)) {
-        rawCategories[cat] = { name: cat, isNew: false };
-      }
-      if (plugin.addedAt && now - plugin.addedAt <= threshold) {
-        rawCategories[cat].isNew = true;
-      }
-    }
-    const categories: CategoryViewDict = Object.fromEntries(
-      Object.entries(rawCategories).sort(([a], [b]) => a.localeCompare(b))
-    );
-
-    let core: Plugin | null = null;
-    if (isSet(iitc_core_user) && isSet(iitc_core_user!['code'])) {
-      core = iitc_core_user!;
-      core['override'] = true;
-    } else if (isSet(iitc_core) && isSet(iitc_core!['code'])) {
-      core = iitc_core!;
-    }
-    return { plugins: data, categories, core };
+    const plugins = this._computePlugins(raw_plugins, plugins_local, plugins_user, plugins_state);
+    const categories = this._computeCategories(plugins);
+    const core = this._computeCore(iitc_core, iitc_core_user);
+    return { plugins, categories, core };
   }
 
   /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -154,8 +154,8 @@ export class Worker {
     await this.storage.set(data);
 
     // Channel-scoped changes only affect the view when they belong to the active channel
-    const channelScopedKeys = ['plugins_catalog', 'plugins_local'];
-    const globalPluginsKeys = ['plugins_user', 'plugins_state', 'channel'];
+    const channelScopedKeys = ['plugins_catalog', 'plugins_local', 'iitc_core'];
+    const globalPluginsKeys = ['plugins_user', 'plugins_state', 'channel', 'iitc_core_user'];
     const affectsView =
       (Object.keys(options).some(k => channelScopedKeys.includes(k)) && channel === this.channel) ||
       Object.keys(options).some(k => globalPluginsKeys.includes(k));
@@ -528,18 +528,22 @@ export class Worker {
   }
 
   /**
-   * Computes a merged view of all plugins and their categories from the three sources.
+   * Computes a merged view of all plugins, categories and IITC core.
    *
    * @param raw_plugins - Dictionary of plugins downloaded from the server.
    * @param plugins_local - Dictionary of installed plugins from IITC-CE distribution.
    * @param plugins_user - Dictionary of external UserScripts.
+   * @param iitc_core - Channel core plugin from storage.
+   * @param iitc_core_user - User-installed core override from storage.
    * @internal
    */
   _computePluginsView(
     raw_plugins: PluginDict,
     plugins_local: PluginDict,
     plugins_user: PluginDict,
-    plugins_state: PluginStateDict
+    plugins_state: PluginStateDict,
+    iitc_core?: Plugin,
+    iitc_core_user?: Plugin
   ): PluginsView {
     if (!isSet(plugins_local)) plugins_local = {};
     if (!isSet(plugins_user)) plugins_user = {};
@@ -606,7 +610,14 @@ export class Worker {
       Object.entries(rawCategories).sort(([a], [b]) => a.localeCompare(b))
     );
 
-    return { plugins: data, categories };
+    let core: Plugin | null = null;
+    if (isSet(iitc_core_user) && isSet(iitc_core_user!['code'])) {
+      core = iitc_core_user!;
+      core['override'] = true;
+    } else if (isSet(iitc_core) && isSet(iitc_core!['code'])) {
+      core = iitc_core!;
+    }
+    return { plugins: data, categories, core };
   }
 
   /**

--- a/test/manager.2.external.spec.ts
+++ b/test/manager.2.external.spec.ts
@@ -763,9 +763,9 @@ describe('manage.js external plugins integration tests', function () {
         external_code
       );
     });
-    it('Check getIITCCore() for custom IITC', async function () {
-      const script = await manager!.getIITCCore();
-      expect(script, 'getIITCCore()').to.have.all.keys(
+    it('Check core in view for custom IITC', async function () {
+      const { core } = await manager!.getPluginsView();
+      expect(core, 'core').to.have.all.keys(
         'author',
         'code',
         'description',
@@ -776,10 +776,8 @@ describe('manage.js external plugins integration tests', function () {
         'uid',
         'version'
       );
-      expect(
-        script!['override'],
-        "getIITCCore() object must have the 'override' parameter set to true"
-      ).to.be.true;
+      expect(core!['override'], "core object must have the 'override' parameter set to true").to.be
+        .true;
     });
     it('Remove custom IITC core script', async function () {
       plugin_event_callback = (data: PluginEventData) => {
@@ -795,9 +793,9 @@ describe('manage.js external plugins integration tests', function () {
       const db_data = await storage.get(['iitc_core_user']);
       expect(db_data['iitc_core_user'], 'iitc_core_user must be empty object').to.deep.equal({});
     });
-    it('Check getIITCCore() for standard IITC', async function () {
-      const script = await manager!.getIITCCore();
-      expect(script, 'getIITCCore()').to.have.all.keys(
+    it('Check core in view for standard IITC', async function () {
+      const { core: script } = await manager!.getPluginsView();
+      expect(script, 'core').to.have.all.keys(
         'uid',
         'author',
         'code',

--- a/test/manager.5.plugins-changed.spec.ts
+++ b/test/manager.5.plugins-changed.spec.ts
@@ -25,6 +25,8 @@ describe('plugins_view_changed callback', function () {
   const first_plugin_uid = 'Plugin A+https://github.com/IITC-CE/ingress-intel-total-conversion';
   const second_plugin_uid = 'Plugin B+https://github.com/IITC-CE/ingress-intel-total-conversion';
   const third_plugin_uid = 'Plugin C+https://github.com/IITC-CE/ingress-intel-total-conversion';
+  const iitc_core_uid =
+    'IITC: Ingress intel map total conversion+https://github.com/IITC-CE/ingress-intel-total-conversion';
 
   const base_config: Omit<ManagerConfig, 'plugins_view_changed'> = {
     storage,
@@ -203,6 +205,28 @@ describe('plugins_view_changed callback', function () {
       for (const cat of Object.values(categories)) {
         expect(cat.isNew, `category ${cat.name} should not be new`).to.be.false;
       }
+    });
+
+    it('core is populated with code after run()', async function () {
+      const { core } = await manager.getPluginsView();
+      expect(core, 'core must not be null after run()').to.not.be.null;
+      expect(core!.uid).to.equal(iitc_core_uid);
+      expect(core!.code).to.be.a('string').and.include('// ==UserScript==');
+    });
+
+    it('core has override flag after user installs iitc core script', async function () {
+      await manager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://github.com/IITC-CE/ingress-intel-total-conversion',
+            name: 'IITC: Ingress intel map total conversion',
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const { core } = await manager.getPluginsView();
+      expect(core!.override).to.be.true;
+      await manager.managePlugin(iitc_core_uid, 'delete');
     });
   });
 });


### PR DESCRIPTION
- `PluginsView` (returned by `getPluginsView()` and `plugins_view_changed`) now includes a `core: Plugin | null` field with the active IITC core script; `core.override` is set when the user has installed a custom core
- `getIITCCore()` removed from the public API - core is now accessible via `getPluginsView().core`
- `_computePluginsView` split into three focused helpers: `_computePlugins`, `_computeCategories`, `_computeCore`
- `_save` now triggers `_emitPluginsChanged` on `iitc_core` and `iitc_core_user` changes so `plugins_view_changed` stays in sync when the core updates