### PR TITLE
fix: strip NUL bytes from plugin code before wrapping

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -43,12 +43,15 @@ export function wrapPluginCode(plugin: Plugin, sourceUrlPrefix: string = ''): st
   const meta = { ...plugin };
   delete meta.code;
 
+  // Strip NUL bytes and ensure trailing newline
+  const stripped = plugin.code!.replaceAll('\x00', '');
+  const pluginCode = stripped.endsWith('\n') ? stripped : `${stripped}\n`;
+
   const code = [
     '((GM)=>{',
     GM_V3_BINDINGS,
     '\n',
-    plugin.code,
-    plugin.code!.endsWith('\n') ? '' : '\n',
+    pluginCode,
     `})(GM(${JSON.stringify({ data_key: dataKey, meta })}))`,
   ].join('');
 


### PR DESCRIPTION
NUL bytes in plugin source could break script injection.
Strip them and normalize the trailing newline at the same time.