### PR TITLE
feat: scope GM API injection to @match patterns of enabled plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,75 @@ if (core) {
 
 Pass `onPluginsViewChanged` in the config (see above), or poll with `getPluginsView()` as needed.
 
+### GM API
+
+When `gmApi` is provided in the config, the library injects a GM API service script once, before
+all other plugins. This script implements the Greasemonkey-compatible API
+(`GM_getValue`, `GM_setValue`, `GM_xmlhttpRequest`, etc.) and communicates with the host app
+via a message bridge.
+
+```js
+const manager = new Manager({
+    storage: browser.storage.local,
+    gmApi: {
+        // JavaScript that sets up window.__iitc_gm_bridge__ in the page context.
+        // Must expose: send(data) and onResponse(callback).
+        bridgeAdapterCode: `
+            window.__iitc_gm_bridge__ = {
+                send(data) { window.postMessage({ type: 'FROM_PAGE', data }, '*'); },
+                onResponse(cb) {
+                    window.addEventListener('message', e => {
+                        if (e.data?.type === 'FROM_EXT') cb(e.data.payload);
+                    });
+                },
+            };
+        `,
+    },
+    injectPlugin: plugin => { /* inject plugin.code into the page */ },
+    onPluginEvent: event => { /* see below */ },
+});
+```
+
+#### GM API match patterns are scoped to enabled plugins
+
+The GM API service script is only injected on pages that match the aggregated `@match` patterns
+of all currently enabled plugins. This avoids injecting it on every page in the browser.
+
+`https://intel.ingress.com/*` is always included as a baseline. Additional patterns are added
+only when an enabled plugin declares a different `@match`. The `onPluginEvent` notification for
+`gm_api` therefore fires only when the match list actually changes - not on every plugin event.
+
+**Mode 1 - `inject()` per page load:**
+
+```js
+const plugins = await manager.getEnabledPlugins();
+// plugins['gm_api'] is always first and contains:
+//   .match - current aggregated @match patterns
+//   .code  - bridge adapter + GM factory combined
+```
+
+**Mode 2 - `onPluginEvent` for content-script registration:**
+
+When a plugin is added, removed, or updated and the aggregated match list changes, `onPluginEvent`
+fires a special event with `uid === 'gm_api'`. Use it to re-register the GM API content script:
+
+```js
+onPluginEvent: event => {
+    if (event.plugins['gm_api']) {
+        const gmApi = event.plugins['gm_api'];
+        // event.event is always 'update'
+        // gmApi.match - new aggregated @match patterns
+        // gmApi.code  - bridge adapter + GM factory to inject at document_start
+        reregisterContentScript(gmApi.match, gmApi.code);
+        return;
+    }
+    // handle regular plugin add/update/remove events...
+},
+```
+
+Plugins without a `@match` header do not contribute to the GM API scope.
+`https://intel.ingress.com/*` is always present regardless of which plugins are enabled.
+
 ### Example of use helpers
 
 ```js

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,10 +1,10 @@
 // Copyright (C) 2022-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
-import { Worker, IITC_CORE_UID, GM_API_UID } from './worker.js';
+import { Worker, IITC_CORE_UID, GM_API_UID, GM_API_DEFAULT_MATCH } from './worker.js';
 import * as migrations from './migrations.js';
 import { getUID, isSet, sanitizeFileName } from './helpers.js';
-import { getGmApiCode } from './gm-api.js';
 import { appendSourceUrl } from './wrapper.js';
+import { aggregateMatchPatterns } from './matching.js';
 import * as backup from './backup.js';
 import type {
   Channel,
@@ -172,21 +172,6 @@ export class Manager extends Worker {
     );
 
     const enabledPlugins: PluginDict = {};
-
-    // GM API (bridge adapter + factory) must be first
-    if (this.gmApi) {
-      enabledPlugins['gm_api'] = {
-        uid: 'gm_api',
-        code: appendSourceUrl({
-          code: this.gmApi.bridgeAdapterCode + '\n' + getGmApiCode(),
-          name: 'GM_api',
-          prefix: this.sourceUrlPrefix,
-          suffix: '.js',
-        }),
-        name: 'GM API',
-        match: ['https://*/*'],
-      };
-    }
     if (iitcScript !== null) {
       if (iitcScript.code) {
         iitcScript.code = appendSourceUrl({
@@ -206,6 +191,17 @@ export class Manager extends Worker {
               : pluginsLocal[uid] || ({} as Plugin);
         }
       }
+    }
+
+    // GM API (bridge adapter + factory) must be first
+    if (this.gmApi) {
+      const matches = Array.from(
+        new Set([GM_API_DEFAULT_MATCH, ...aggregateMatchPatterns(enabledPlugins)])
+      ).sort();
+      return {
+        [GM_API_UID]: this._buildGmApiPlugin(matches),
+        ...enabledPlugins,
+      };
     }
     return enabledPlugins;
   }

--- a/src/matching.ts
+++ b/src/matching.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2023-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
-import type { PluginMeta } from './types.js';
+import type { PluginDict, PluginMeta } from './types.js';
 
 interface Matcher {
   test(url: string): boolean;
@@ -120,6 +120,22 @@ function matchHost(rule: string, data: string): boolean {
 
 function matchPath(rule: string, data: string): boolean {
   return str2RE(rule).test(data);
+}
+
+/**
+ * Collects all unique @match patterns from a dictionary of plugins.
+ * Plugins without @match are skipped. Returns a sorted, deduplicated array.
+ *
+ * @param plugins - Dictionary of plugins to aggregate match patterns from.
+ */
+export function aggregateMatchPatterns(plugins: PluginDict): string[] {
+  const set = new Set<string>();
+  for (const plugin of Object.values(plugins)) {
+    for (const pattern of plugin.match || []) {
+      set.add(pattern);
+    }
+  }
+  return Array.from(set).sort();
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,10 @@ export type PluginEventType = 'add' | 'update' | 'remove';
 /**
  * Plugin event object passed to the onPluginEvent callback.
  * Contains plugin data for 'add'/'update' events, or empty objects for 'remove' events.
+ *
+ * When `uid === 'gm_api'`, this is a special notification that the GM API scope has changed.
+ * The event type is always `'update'` and `plugins['gm_api'].match` contains the current
+ * aggregated list of @match patterns from all enabled plugins.
  */
 export interface PluginEventData {
   /** The type of plugin event. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,9 @@
 // Copyright (C) 2022-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { fetchResource, clearWait, getUID, isSet, parseMeta, wait } from './helpers.js';
-import { wrapPluginCode } from './wrapper.js';
+import { wrapPluginCode, appendSourceUrl } from './wrapper.js';
+import { getGmApiCode } from './gm-api.js';
+import { aggregateMatchPatterns } from './matching.js';
 import type {
   Channel,
   ManagerConfig,
@@ -26,6 +28,7 @@ import type {
 export const IITC_CORE_UID =
   'IITC: Ingress intel map total conversion+https://github.com/IITC-CE/ingress-intel-total-conversion';
 export const GM_API_UID = 'gm_api';
+export const GM_API_DEFAULT_MATCH = 'https://intel.ingress.com/*';
 
 /**
  * This class contains methods for managing IITC and plugins.
@@ -50,6 +53,7 @@ export class Worker {
   onPluginEvent: (event: PluginEventData) => void;
   onPluginsViewChanged?: (view: PluginsView) => void;
   newPluginThreshold: number;
+  _gmApiMatches: string[];
 
   /**
    * Creates an instance of Manager class with the specified parameters
@@ -74,6 +78,7 @@ export class Worker {
     this.onPluginsViewChanged = this.config.onPluginsViewChanged;
     this.newPluginThreshold = this.config.newPluginThreshold ?? 3600;
 
+    this._gmApiMatches = [GM_API_DEFAULT_MATCH];
     this.isInitialized = false;
     this._init().then();
   }
@@ -157,6 +162,61 @@ export class Worker {
     if (affectsView) {
       this._emitPluginsChanged();
     }
+  }
+
+  /**
+   * Builds the gm_api pseudo-plugin with the given aggregated match patterns.
+   * @internal
+   */
+  _buildGmApiPlugin(matches: string[]): Plugin {
+    return {
+      uid: GM_API_UID,
+      name: 'GM API',
+      match: matches,
+      code: appendSourceUrl({
+        code: this.gmApi!.bridgeAdapterCode + '\n' + getGmApiCode(),
+        name: 'GM_api',
+        prefix: this.sourceUrlPrefix,
+        suffix: '.js',
+      }),
+    };
+  }
+
+  /**
+   * Reads storage and computes the aggregated set of @match patterns
+   * from IITC core and all currently enabled plugins.
+   * @internal
+   */
+  async _computeGmApiMatches(): Promise<string[]> {
+    const channel = this.channel;
+    const data = await this.storage.get([
+      `${channel}_iitc_core`,
+      'iitc_core_user',
+      `${channel}_plugins_local`,
+      'plugins_user',
+      'plugins_state',
+    ]);
+
+    const pluginsLocal = (data[`${channel}_plugins_local`] || {}) as PluginDict;
+    const pluginsUser = (data['plugins_user'] || {}) as PluginDict;
+    const pluginsState = (data['plugins_state'] || {}) as PluginStateDict;
+    const iitcCore = data[`${channel}_iitc_core`] as Plugin | undefined;
+    const iitcCoreUser = data['iitc_core_user'] as Plugin | undefined;
+
+    const candidates: PluginDict = {};
+
+    const core = this._computeCore(iitcCore, iitcCoreUser);
+    if (core) candidates[IITC_CORE_UID] = core;
+
+    for (const uid in pluginsState) {
+      if (pluginsState[uid]?.status !== 'on') continue;
+      const plugin = uid in pluginsUser ? pluginsUser[uid] : pluginsLocal[uid];
+      if (plugin) candidates[uid] = plugin;
+    }
+
+    return Array.from(
+      new Set([GM_API_DEFAULT_MATCH, ...aggregateMatchPatterns(candidates)])
+    ).sort();
   }
 
   /**
@@ -714,6 +774,17 @@ export class Worker {
         event,
         plugins,
       });
+    }
+
+    if (this.gmApi) {
+      const newMatches = await this._computeGmApiMatches();
+      if (newMatches.join('\0') !== this._gmApiMatches.join('\0')) {
+        this._gmApiMatches = newMatches;
+        this.onPluginEvent({
+          event: 'update',
+          plugins: { [GM_API_UID]: this._buildGmApiPlugin(newMatches) },
+        });
+      }
     }
   }
 

--- a/test/manager.4.gm-api.spec.ts
+++ b/test/manager.4.gm-api.spec.ts
@@ -2,9 +2,10 @@
 
 import { describe, it, before } from 'mocha';
 import { Manager } from '../src/manager.js';
+import { GM_API_UID } from '../src/worker.js';
 import storage from '../test/storage.js';
 import { expect } from 'chai';
-import type { ManagerConfig, Plugin } from '../src/types.js';
+import type { ManagerConfig, Plugin, PluginEventData } from '../src/types.js';
 
 describe('Manager GM API integration', function () {
   const injectedPlugins: Plugin[] = [];
@@ -99,12 +100,12 @@ describe('Manager GM API integration', function () {
       await manager.run();
     });
 
-    it('should include GM API with match patterns and combined code', async function () {
+    it('should include GM API with match patterns aggregated from enabled plugins', async function () {
       const plugins = await manager.getEnabledPlugins();
       const gmApi = plugins['gm_api'];
 
       expect(gmApi).to.exist;
-      expect(gmApi.match).to.deep.equal(['https://*/*']);
+      expect(gmApi.match).to.deep.equal(['https://intel.ingress.com/*']);
       expect(gmApi.code).to.include('__iitc_gm_bridge__');
       expect(gmApi.code).to.include('window.GM');
     });
@@ -127,6 +128,148 @@ describe('Manager GM API integration', function () {
     it('should not include GM API', async function () {
       const plugins = await manager.getEnabledPlugins();
       expect(plugins).to.not.have.property('gm_api');
+    });
+  });
+
+  describe('GM API match aggregation in getEnabledPlugins()', function () {
+    const pluginAUid = 'Plugin A+https://github.com/IITC-CE/ingress-intel-total-conversion';
+    let manager: Manager;
+
+    before(async function () {
+      manager = createManager(true);
+      await manager.run();
+    });
+
+    it('match list contains only IITC core pattern when no extra plugins enabled', async function () {
+      const plugins = await manager.getEnabledPlugins();
+      expect(plugins[GM_API_UID].match).to.deep.equal(['https://intel.ingress.com/*']);
+    });
+
+    it('enabling a plugin with same @match does not duplicate the pattern', async function () {
+      await manager.managePlugin(pluginAUid, 'on');
+      const plugins = await manager.getEnabledPlugins();
+      expect(plugins[GM_API_UID].match).to.deep.equal(['https://intel.ingress.com/*']);
+    });
+
+    it('enabling a plugin with extra @match expands the list', async function () {
+      await manager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://example.com',
+            name: 'External Plugin',
+            match: ['https://example.com/*'],
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const plugins = await manager.getEnabledPlugins();
+      expect(plugins[GM_API_UID].match).to.include('https://example.com/*');
+      expect(plugins[GM_API_UID].match).to.include('https://intel.ingress.com/*');
+    });
+  });
+
+  describe('onPluginEvent gm_api update notification', function () {
+    const pluginAUid = 'Plugin A+https://github.com/IITC-CE/ingress-intel-total-conversion';
+
+    function nextGmApiEvent(manager: Manager): Promise<PluginEventData> {
+      return new Promise(resolve => {
+        const prev = manager.onPluginEvent;
+        manager.onPluginEvent = (event: PluginEventData) => {
+          if (event.plugins[GM_API_UID]) {
+            manager.onPluginEvent = prev;
+            if (prev) prev(event);
+            resolve(event);
+          } else {
+            if (prev) prev(event);
+          }
+        };
+      });
+    }
+
+    it('does not emit gm_api update after run() when IITC core match equals the default', async function () {
+      storage.resetStorage();
+      let gmApiEventFired = false;
+      const manager = new Manager({
+        storage,
+        channel: 'release',
+        networkHost: {
+          release: 'http://127.0.0.1:31606/release',
+          beta: 'http://127.0.0.1:31606/beta',
+          custom: 'http://127.0.0.1/',
+        },
+        injectPlugin: () => {},
+        onProgress: () => {},
+        isDaemon: false,
+        gmApi: { bridgeAdapterCode: 'window.__iitc_gm_bridge__ = { send() {}, onResponse() {} };' },
+        onPluginEvent: (event: PluginEventData) => {
+          if (event.plugins[GM_API_UID]) gmApiEventFired = true;
+        },
+      });
+      await manager.run();
+      expect(gmApiEventFired).to.be.false;
+    });
+
+    it('emits gm_api update when a plugin with new @match is enabled', async function () {
+      storage.resetStorage();
+      const manager = createManager(true);
+      await manager.run();
+
+      const gmApiEvent = nextGmApiEvent(manager);
+      await manager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://example.com',
+            name: 'Extra Plugin',
+            match: ['https://example.com/*'],
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+      const event = await gmApiEvent;
+      expect(event.event).to.equal('update');
+      expect((event.plugins[GM_API_UID] as Plugin).match).to.include('https://example.com/*');
+    });
+
+    it('does not emit gm_api update when enabling a plugin with already-covered @match', async function () {
+      storage.resetStorage();
+      const manager = createManager(true);
+      await manager.run();
+
+      let gmApiEventFired = false;
+      const prev = manager.onPluginEvent;
+      manager.onPluginEvent = (event: PluginEventData) => {
+        if (event.plugins[GM_API_UID]) gmApiEventFired = true;
+        if (prev) prev(event);
+      };
+
+      // Plugin A has same @match as IITC core, so match set should not change
+      await manager.managePlugin(pluginAUid, 'on');
+
+      expect(gmApiEventFired).to.be.false;
+    });
+
+    it('emits gm_api update when plugin with unique @match is disabled', async function () {
+      storage.resetStorage();
+      const manager = createManager(true);
+      await manager.run();
+
+      const extUid = 'Extra Plugin+https://example.com';
+      await manager.addUserScripts([
+        {
+          meta: {
+            namespace: 'https://example.com',
+            name: 'Extra Plugin',
+            match: ['https://example.com/*'],
+          },
+          code: '// ==UserScript==\nreturn false;',
+        },
+      ]);
+
+      const gmApiEvent = nextGmApiEvent(manager);
+      await manager.managePlugin(extUid, 'off');
+      const event = await gmApiEvent;
+      expect(event.event).to.equal('update');
+      expect((event.plugins[GM_API_UID] as Plugin).match).to.not.include('https://example.com/*');
     });
   });
 });

--- a/test/matching.spec.ts
+++ b/test/matching.spec.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2023-2026 IITC-CE - GPL-3.0 with Store Exception - see LICENSE and COPYING.STORE
 
 import { describe, it } from 'mocha';
-import { checkMatching, humanizeMatch } from '../src/matching.js';
+import { aggregateMatchPatterns, checkMatching, humanizeMatch } from '../src/matching.js';
 import { expect } from 'chai';
-import type { PluginMeta } from '../src/types.js';
+import type { PluginDict, PluginMeta } from '../src/types.js';
 
 describe('scheme', function () {
   it('should match all', function () {
@@ -129,6 +129,53 @@ describe('<all_ingress>', function () {
     expect(checkMatching(script, 'https://intel.ingress.com/'), 'not match real url').to.be.false;
     expect(checkMatching(script, '<all_ingress>'), 'should match keyword `<all_ingress>`').to.be
       .true;
+  });
+});
+
+describe('aggregateMatchPatterns()', function () {
+  it('returns empty array for empty plugin dict', function () {
+    expect(aggregateMatchPatterns({})).to.deep.equal([]);
+  });
+
+  it('returns empty array when no plugin has @match', function () {
+    const plugins: PluginDict = {
+      a: { uid: 'a', name: 'A' },
+    };
+    expect(aggregateMatchPatterns(plugins)).to.deep.equal([]);
+  });
+
+  it('collects patterns from a single plugin', function () {
+    const plugins: PluginDict = {
+      a: { uid: 'a', name: 'A', match: ['https://intel.ingress.com/*'] },
+    };
+    expect(aggregateMatchPatterns(plugins)).to.deep.equal(['https://intel.ingress.com/*']);
+  });
+
+  it('deduplicates identical patterns across plugins', function () {
+    const plugins: PluginDict = {
+      a: { uid: 'a', name: 'A', match: ['https://intel.ingress.com/*'] },
+      b: { uid: 'b', name: 'B', match: ['https://intel.ingress.com/*'] },
+    };
+    expect(aggregateMatchPatterns(plugins)).to.deep.equal(['https://intel.ingress.com/*']);
+  });
+
+  it('merges patterns from multiple plugins and sorts the result', function () {
+    const plugins: PluginDict = {
+      a: { uid: 'a', name: 'A', match: ['https://example.com/*'] },
+      b: { uid: 'b', name: 'B', match: ['https://intel.ingress.com/*', 'https://example.com/*'] },
+    };
+    expect(aggregateMatchPatterns(plugins)).to.deep.equal([
+      'https://example.com/*',
+      'https://intel.ingress.com/*',
+    ]);
+  });
+
+  it('skips plugins without @match field', function () {
+    const plugins: PluginDict = {
+      a: { uid: 'a', name: 'A', match: ['https://intel.ingress.com/*'] },
+      b: { uid: 'b', name: 'B' },
+    };
+    expect(aggregateMatchPatterns(plugins)).to.deep.equal(['https://intel.ingress.com/*']);
   });
 });
 


### PR DESCRIPTION
- The GM API service script (`gm_api`) used to declare `@match: ['https://*/*']`, causing it to be injected on every HTTPS page in the browser. It is now scoped to the union of `@match` patterns from all enabled plugins.
- `https://intel.ingress.com/*` is always present as a baseline default, so no extra `onPluginEvent` fires on a typical startup where only IITC core (targeting intel.ingress.com) is active.
- When a plugin with a non-standard `@match` is enabled or disabled, `onPluginEvent` fires with `uid === 'gm_api'` and `event === 'update'`, giving the host app the new match list to re-register its content script.