### PR TITLE
fix: save null instead of {} when removing IITC core override

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -313,7 +313,7 @@ export class Manager extends Worker {
     }
     if (action === 'delete') {
       if (uid === IITC_CORE_UID) {
-        await this._save(channel, { iitc_core_user: {} });
+        await this._save(channel, { iitc_core_user: null });
         await this._sendPluginsEvent(channel, [uid], 'update');
       } else {
         const isEnabled = pluginsState[uid]?.status === 'on';

--- a/test/manager.2.external.spec.ts
+++ b/test/manager.2.external.spec.ts
@@ -770,14 +770,15 @@ describe('manage.js external plugins integration tests', function () {
         expect(data).to.have.all.keys('event', 'plugins');
         expect(data['event']).to.equal('update');
         expect(data['plugins']).to.have.all.keys(iitcCustomUid);
-        expect(data['plugins'][iitcCustomUid]).to.be.empty;
+        expect(data['plugins'][iitcCustomUid]).to.have.property('uid', iitcCustomUid);
+        expect(data['plugins'][iitcCustomUid]).to.have.property('code');
       };
 
       const run = await manager!.managePlugin(iitcCustomUid, 'delete');
       expect(run).to.be.undefined;
 
       const dbData = await storage.get(['iitc_core_user']);
-      expect(dbData['iitc_core_user'], 'iitc_core_user must be empty object').to.deep.equal({});
+      expect(dbData['iitc_core_user']).to.be.null;
     });
     it('Check core in view for standard IITC', async function () {
       const { core: script } = await manager!.getPluginsView();


### PR DESCRIPTION
{} caused isSet() to return true, so plugin_event fired with an empty plugin object, leaving the old user script active in Chrome.