### PR TITLE
fix: wrap IITC core with GM IIFE like regular plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-iitc-manager",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Library for managing IITC plugins",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,7 +41,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "http-server": "^14.1.0",
-    "mocha": "^9.2.2",
+    "mocha": "^11.7.5",
     "node-fetch": "^3.2.3",
     "prettier": "^2.7.1",
     "tsx": "^4.21.0",

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -236,12 +236,9 @@ export class Manager extends Worker {
       if (!plugin || !plugin.code) continue;
 
       const isGmComponent = uid === GM_API_UID;
-      const isCore = uid === IITC_CORE_UID;
 
       if (isGmComponent) {
         await this.injectPlugin(plugin);
-      } else if (isCore) {
-        this.injectPlugin(plugin);
       } else {
         this._injectWithGmApi(plugin);
       }

--- a/test/manager.4.gm-api.spec.ts
+++ b/test/manager.4.gm-api.spec.ts
@@ -81,14 +81,14 @@ describe('Manager GM API integration', function () {
       expect(injectedPlugins[0].code).to.include('window.GM');
     });
 
-    it('should not wrap IITC core code with GM IIFE', async function () {
+    it('should wrap IITC core code with GM IIFE', async function () {
       injectedPlugins.length = 0;
       await manager.inject();
       // Second plugin should be IITC core (after GM API)
       const iitcPlugin = injectedPlugins[1];
       expect(iitcPlugin).to.exist;
       expect(iitcPlugin.code).to.include('==UserScript==');
-      expect(iitcPlugin.code).to.not.match(/^\(\(GM\)=>\{/);
+      expect(iitcPlugin.code).to.match(/^\(\(GM\)=>\{/);
     });
   });
 


### PR DESCRIPTION
Remove the special case that bypassed GM API wrapping for IITC core in `inject()`. Core is now passed through `_injectWithGmApi` along with other plugins, consistent with how `_sendPluginsEvent` already handles it.