### PR TITLE
fix: preserve disabled external plugins when restoring a backup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-iitc-manager",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Library for managing IITC plugins",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -487,11 +487,11 @@ export class Manager extends Worker {
     // Process the input parameters using the 'paramsProcessing' function from the 'backup' module.
     const processedParams = backup.paramsProcessing(params);
 
-    if (processedParams.settings)
-      await backup.importIitcSettings(this, backupData.data.iitc_settings);
-    if (processedParams.data)
-      await backup.importPluginsSettings(this, backupData.data.plugins_data);
     if (processedParams.external)
       await backup.importExternalPlugins(this, backupData.external_plugins);
+    if (processedParams.data)
+      await backup.importPluginsSettings(this, backupData.data.plugins_data);
+    if (processedParams.settings)
+      await backup.importIitcSettings(this, backupData.data.iitc_settings);
   }
 }

--- a/test/manager.9.backup.spec.ts
+++ b/test/manager.9.backup.spec.ts
@@ -223,3 +223,55 @@ describe('getBackupData and setBackupData', function () {
     });
   });
 });
+
+describe('setBackupData preserves the disabled state of restored external plugins', function () {
+  // The backup marks an external plugin as "off", but addUserScripts() force-enables
+  // every re-installed script. The import order must keep the backup's status.
+  const pluginExtCode =
+    '// ==UserScript==\n' +
+    '// @name PluginExt\n' +
+    '// @namespace https://github.com/IITC-CE/ingress-intel-total-conversion\n' +
+    '// ==/UserScript==\n' +
+    'return false;';
+  const pluginExtUid = 'PluginExt+https://github.com/IITC-CE/ingress-intel-total-conversion';
+  const restoreBackup: BackupData = {
+    external_plugins: {
+      shared: {
+        'PluginExt.user.js': pluginExtCode,
+      },
+    },
+    data: {
+      iitc_settings: {
+        channel: 'release',
+        plugins_state: {
+          [pluginExtUid]: { status: 'off' },
+        },
+      },
+      plugins_data: {},
+      app: 'IITC Button',
+    },
+  };
+
+  it('Keeps the off status from the backup after re-installing the code', async function () {
+    storage.resetStorage();
+    const manager = new Manager({
+      storage: storage,
+      channel: 'release',
+      networkHost: {
+        release: 'http://127.0.0.1:31606/release',
+        beta: 'http://127.0.0.1:31606/beta',
+        custom: 'http://127.0.0.1/',
+      },
+      injectPlugin: () => {},
+      onProgress: () => {},
+      isDaemon: false,
+    });
+    await manager.run();
+
+    await manager.setBackupData({ settings: true, data: true, external: true }, restoreBackup);
+
+    const pluginsState = (await storage.get(['plugins_state']))['plugins_state'] as StorageData;
+    const entry = pluginsState[pluginExtUid] as StorageData;
+    expect(entry['status']).to.equal('off');
+  });
+});


### PR DESCRIPTION
On restore, external plugins saved as "off" came back "on". `setBackupData` ran `importIitcSettings` (writes `plugins_state` from the backup) before `importExternalPlugins`, whose `addUserScripts` unconditionally re-enables
every re-installed script - overwriting the just-imported states. Built-in plugins were unaffected (their code isn't reinstalled), so only third-party plugins broke.

Reorder `setBackupData` to import external plugins (and plugins data) first and apply IITC settings last, so the backup's `plugins_state` is the final write and wins.