### PR TITLE
feat: expose a ready promise for async initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-iitc-manager",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Library for managing IITC plugins",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -99,10 +99,7 @@ export class Manager extends Worker {
    * Migrates data storage as needed, then loads or updates UserScripts from the repositories.
    */
   async run(): Promise<void> {
-    if (!this.isInitialized) {
-      await new Promise(resolve => setTimeout(resolve, 1));
-      return await this.run();
-    }
+    await this.ready;
     const isMigrated = await migrations.migrate(this.storage);
     await this.checkUpdates(isMigrated);
     if (isMigrated) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,8 @@ export class Worker {
   isDaemon!: boolean;
   useFetchHeadMethod!: boolean;
   isInitialized: boolean;
+  /** Resolves once _init has loaded channel, networkHost and other settings from storage */
+  ready: Promise<void>;
   gmApi?: GmApiConfig;
   sourceUrlPrefix: string;
   appName: string;
@@ -86,7 +88,7 @@ export class Worker {
 
     this._gmApiMatches = [GM_API_DEFAULT_MATCH];
     this.isInitialized = false;
-    this._init().then();
+    this.ready = this._init();
   }
 
   /**


### PR DESCRIPTION
The constructor's _init runs asynchronously, so channel/networkHost are undefined until it resolves. Store its promise in a public `ready` field so consumers can await initialization; `run()` now awaits it instead of polling `isInitialized`.